### PR TITLE
Deploy CMake for batch version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 .gitignore
 #README.md
 
-# CMake
-CMakeLists.txt
-
 # CodeLite
 /.build-debug/
 /Debug/
@@ -14,11 +11,9 @@ compile_commands.json
 Makefile
 .build-release/
 build-Release/
-*.txt
 *.project
 *.workspace
 *.mk
-*.txt
 *.tags
 
 # Hidden source

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ vignettes/*.pdf
 
 # compilation files
 *.o
+
+# Visual Studio
+.vs/
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .gitignore
 #README.md
 
+# CMake
+CMakeLists.txt
+
 # CodeLite
 /.build-debug/
 /Debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,8 @@
 add_library(RScore Species.cpp Cell.cpp Community.cpp FractalGenerator.cpp Genome.cpp Individual.cpp Landscape.cpp Model.cpp Parameters.cpp Patch.cpp Population.cpp RandomCheck.cpp RSrandom.cpp SubCommunity.cpp)
 
 # pass config definitions to compiler
-target_compile_definitions(RScore PRIVATE "RSDEBUG" "LINUX_CLUSTER" "RSWIN64" "BATCH")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	target_compile_definitions(RScore PRIVATE "RSDEBUG" "RSWIN64" "LINUX_CLUSTER")
+else() # Windows
+	target_compile_definitions(RScore PRIVATE "RSDEBUG" "RSWIN64")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Config file for compilation with CMake
+# Only relevant for Batch mode, but this file needs to live in the RScore folder
+
+add_library(RScore Species.cpp Cell.cpp Community.cpp FractalGenerator.cpp Genome.cpp Individual.cpp Landscape.cpp Model.cpp Parameters.cpp Patch.cpp Population.cpp RandomCheck.cpp RSrandom.cpp SubCommunity.cpp)
+
+# pass config definitions to compiler
+target_compile_definitions(RScore PRIVATE "RSDEBUG" "LINUX_CLUSTER" "RSWIN64" "BATCH")

--- a/Community.h
+++ b/Community.h
@@ -52,9 +52,9 @@ Last updated: 25 June 2021 by Anne-Kathleen Malchow
 #include <vector>
 #include <algorithm>
 using namespace std;
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"

--- a/Community.h
+++ b/Community.h
@@ -52,13 +52,7 @@ Last updated: 25 June 2021 by Anne-Kathleen Malchow
 #include <vector>
 #include <algorithm>
 using namespace std;
-#if RS_RCPP
-#include "../Version.h"
-#endif
 
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
 #include "SubCommunity.h"
 #include "Landscape.h"
 #include "Patch.h"

--- a/Model.cpp
+++ b/Model.cpp
@@ -152,17 +152,10 @@ DEBUGLOG << endl << "RunModel(): generating new landscape ..." << endl;
 DEBUGLOG << "RunModel(): finished resetting landscape" << endl << endl;
 #endif
 		pLandscape->generatePatches();
-//#if VCL
 		if (v.viewLand || sim.saveMaps) {
 			pLandscape->setLandMap();
 			pLandscape->drawLandscape(rep,0,ppLand.landNum);
 		}
-//#endif
-//#if BATCH
-//		if (sim.saveMaps) {
-//			pLandscape->drawLandscape(rep,0,ppLand.landNum);
-//		}
-//#endif
 #if RSDEBUG
 DEBUGLOG << endl << "RunModel(): finished generating patches" << endl;
 #endif
@@ -313,12 +306,8 @@ DEBUGLOG << "RunModel(): completed updating carrying capacity" << endl;
 DEBUGLOG << "RunModel(): completed initialisation, rep=" << rep
 	<< " pSpecies=" << pSpecies << endl;
 #endif
-#if BATCH
-#if RS_RCPP && !R_CMD
+#if BATCH && RS_RCPP && !R_CMD
 	Rcpp::Rcout << "RunModel(): completed initialisation " << endl;
-#else
-	cout << "RunModel(): completed initialisation " << endl;
-#endif
 #endif
 
 	// open a new individuals file for each replicate
@@ -926,7 +915,7 @@ return errorfolder;
 //For outputs and population visualisations pre-reproduction
 void PreReproductionOutput(Landscape *pLand,Community *pComm,int rep,int yr,int gen)
 {
-#if RSDEBUG || VCL
+#if RSDEBUG
 landParams ppLand = pLand->getLandParams();
 #endif
 simParams sim = paramsSim->getSim();
@@ -1341,22 +1330,6 @@ if (dem.stageStruct){
 			outPar << endl;
 		}
 	}
-#if VCL
-	else {
-
-	// NOTE: TO PREVENT COMPILING FOR BATCH MODE, THIS CODE NEEDS TO BE INCLUDED IN COMPILER
-	// CONDITIONAL BLOCK  AS SHOWN
-
-//	outPar << "Row count: " << frmSpecies->transMatrix->RowCount << endl;
-//	outPar << "Col count: " << frmSpecies->transMatrix->ColCount << endl;
-		for (int i = 1; i < frmSpecies->transMatrix->RowCount; i++) {
-			for (int j = 1; j < frmSpecies->transMatrix->ColCount; j++) {
-				outPar << frmSpecies->transMatrix->Cells[j][i].ToDouble() << "\t";
-			}
-			outPar << endl;
-		}
-	}
-#endif
 	outPar << endl;
 #endif
 */

--- a/Model.h
+++ b/Model.h
@@ -49,14 +49,6 @@ Last updated: 26 October 2021 by Steve Palmer
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#if RS_RCPP
-#include "../Version.h"
-#endif
-
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
-
 #include "Parameters.h"
 #include "Landscape.h"
 #include "Community.h"

--- a/Model.h
+++ b/Model.h
@@ -75,12 +75,12 @@ extern ofstream DEBUGLOG;
 #if RS_RCPP && !R_CMD
 Rcpp::List RunModel(
 	Landscape*,	// pointer to Landscape
-	int					// sequential simulation number (always 0 for VCL version)
+	int					// sequential simulation number
 );
 #else
 int RunModel(
 	Landscape*,	// pointer to Landscape
-	int					// sequential simulation number (always 0 for VCL version)
+	int					// sequential simulation number
 );
 #endif // RS_RCPP && !R_CMD
 bool CheckDirectory(void);
@@ -125,11 +125,11 @@ extern Community *pComm;
 const bool batchMode = true;
 extern string landFile;
 extern vector <string> hfnames;
-extern string habmapname;		// see FormLand.cpp (VCL) OR Main.cpp (batch)
-extern string patchmapname;	// see FormLand.cpp (VCL) OR Main.cpp (batch)
-extern string distnmapname;	// see FormLand.cpp (VCL) OR Main.cpp (batch)
-extern string costmapname;	// see FormMove.cpp (VCL) OR Main.cpp (batch)
-extern string genfilename;	// see FormGenetics.cpp (VCL) OR Main.cpp (batch)
+extern string habmapname;		// see Main.cpp (batch)
+extern string patchmapname;	// see Main.cpp (batch)
+extern string distnmapname;	// see Main.cpp (batch)
+extern string costmapname;	// see Main.cpp (batch)
+extern string genfilename;	// see Main.cpp (batch)
 extern RSrandom *pRandom;
 
 // these functions to have different version for GUI and batch applications ...

--- a/Model.h
+++ b/Model.h
@@ -49,9 +49,9 @@ Last updated: 26 October 2021 by Steve Palmer
 #include <sys/types.h>
 #include <sys/stat.h>
 
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"

--- a/Parameters.h
+++ b/Parameters.h
@@ -60,9 +60,9 @@ Last updated: 25 June 2021 by Steve Palmer
 #include <stdlib.h>
 #include <vector>
 using namespace std;
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"

--- a/Parameters.h
+++ b/Parameters.h
@@ -60,13 +60,6 @@ Last updated: 25 June 2021 by Steve Palmer
 #include <stdlib.h>
 #include <vector>
 using namespace std;
-#if RS_RCPP
-#include "../Version.h"
-#endif
-
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
 
 #include "RSrandom.h"
 

--- a/Patch.h
+++ b/Patch.h
@@ -68,14 +68,6 @@ Last updated: 25 June 2021 by Steve Palmer
 #include <vector>
 using namespace std;
 
-#if RS_RCPP
-#include "../Version.h"
-#endif
-
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
-
 #include "Parameters.h"
 #include "Cell.h"
 #include "Species.h"

--- a/Patch.h
+++ b/Patch.h
@@ -68,9 +68,9 @@ Last updated: 25 June 2021 by Steve Palmer
 #include <vector>
 using namespace std;
 
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"

--- a/Population.cpp
+++ b/Population.cpp
@@ -433,12 +433,6 @@ void Population::reproduction(const float localK,const float envval,const int re
 int ninds = (int)inds.size();
 #if RSDEBUG
 //DEBUGLOG << "Population::reproduction(): this=" << this
-//#if BUTTERFLYDISP
-//	<< " option=" << option
-//#endif // BUTTERFLYDISP 
-//#if RS_CONTAIN
-//	<< " hab=" << hab
-//#endif // RS_CONTAIN 
 //	<< " ninds=" << ninds
 //	<< endl;
 #endif // RSDEBUG 
@@ -464,12 +458,8 @@ if (dem.repType == 0) nsexes = 1; else nsexes = 2;
 
 #if RSDEBUG
 //DEBUGLOG << "Population::reproduction(): this=" << this
-//#if RS_CONTAIN
-//	<< " hab=" << hab
-//#else
 //	<< " pSpecies=" << pSpecies
 //	<< " localK=" << localK << " envval=" << envval << " resol=" << resol
-//#endif // RS_CONTAIN 
 //	<< " sstruct.nStages=" << sstruct.nStages << " nsexes=" << nsexes << " ninds=" << ninds
 //	<< endl;
 #endif

--- a/RSrandom.h
+++ b/RSrandom.h
@@ -38,15 +38,6 @@ Last updated: 12 January 2021 by Steve Palmer
 
 #include <stdlib.h>
 #include <fstream>
-//#include <iostream>
-
-#if RS_RCPP
-#include "../Version.h"
-#endif
-
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
 
 using namespace std;
 

--- a/RSrandom.h
+++ b/RSrandom.h
@@ -40,9 +40,9 @@ Last updated: 12 January 2021 by Steve Palmer
 #include <fstream>
 //#include <iostream>
 
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"

--- a/RandomCheck.h
+++ b/RandomCheck.h
@@ -28,9 +28,9 @@
 #include <fstream>
 using namespace std;
 
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"

--- a/RandomCheck.h
+++ b/RandomCheck.h
@@ -28,13 +28,6 @@
 #include <fstream>
 using namespace std;
 
-#if RS_RCPP
-#include "../Version.h"
-#endif
-
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
 #include "Parameters.h"
 #include "RSrandom.h"
 

--- a/Species.h
+++ b/Species.h
@@ -45,13 +45,6 @@ Last updated: 28 July 2021 by Greta Bocedi
 #ifndef SpeciesH
 #define SpeciesH
 
-#if RS_RCPP
-#include "../Version.h"
-#endif
-
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
 #include "Parameters.h"
 
 // structures for demographic parameters

--- a/Species.h
+++ b/Species.h
@@ -45,9 +45,9 @@ Last updated: 28 July 2021 by Greta Bocedi
 #ifndef SpeciesH
 #define SpeciesH
 
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -50,14 +50,6 @@ Last updated: 26 October 2021 by Steve Palmer
 #include <algorithm>
 using namespace std;
 
-#if RS_RCPP
-#include "../Version.h"
-#endif
-
-//#if !RS_RCPP && R_CMD
-//#include "../../Batch/Version.h"
-//#endif
-
 #include "Parameters.h"
 #include "Landscape.h"
 #include "Population.h"

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -50,9 +50,9 @@ Last updated: 26 October 2021 by Steve Palmer
 #include <algorithm>
 using namespace std;
 
-//#if RS_RCPP && !R_CMD
+#if RS_RCPP
 #include "../Version.h"
-//#endif
+#endif
 
 //#if !RS_RCPP && R_CMD
 //#include "../../Batch/Version.h"


### PR DESCRIPTION
A few changes to enable building the batch version with CMake (https://github.com/RangeShifter/RangeShifter_batch_dev/issues/15). I do not expect it to disrupt building RangeShiftR, but please do signal if it does and I will search for a workaround.

- Added a **CMakeLists.txt** specifying how CMake should configure and compile RScore as a library, before linking to the larger batch executable. This document needs to live in RScore, as the `add_library` command can only add files in the same folder.
- Made `include "Version.h"` conditional on `RS_RCPP`. Thanks to CMake, the batch version does not need to (and cannot) keep a Version script to enable the macros.

I also removed a bunch of unused macro blocks, e.g. VCL and BATCH.