### PR TITLE
added a fix for issue #12 in Landscape.cpp

### DIFF
--- a/Landscape.cpp
+++ b/Landscape.cpp
@@ -2615,8 +2615,10 @@ costs >> header;
 	costs.close(); costs.clear();
 	return -1;
 }
+double tmpresolCost;		
 costs >> maxXcost >> header >> maxYcost >> header >> minLongCost;
-costs >> header >> minLatCost >> header >> resolCost >> header >> NODATACost;
+costs >> header >> minLatCost >> header >> tmpresolCost >> header >> NODATACost;
+resolCost = (int) tmpresolCost;
 
 #if !RS_RCPP
 MemoLine("Loading costs map. Please wait...");


### PR DESCRIPTION
Forgot to apply temporary cellsize variable for cost layer (needed temporarily a double for reading, but is transformed into an integer)