### PR TITLE
Bugfix in SMS:

### DIFF
--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1266,7 +1266,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	array3x3d goal;	// to hold weights for moving towards a goal location
 	array3x3f hab;	// to hold weights for habitat (includes percep range)
 	int x2, y2; 			// x index from 0=W to 2=E, y index from 0=N to 2=S
-	int newX = -9, newY = -9; // BUGFIX: must not be 0 because 0,0 is a valid landscape cell
+	int newX = -9, newY = -9;
 	Cell* pCell;
 	Cell* pNewCell = NULL;
 	double sum_nbrs = 0.0;

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1225,7 +1225,8 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 
 		} // end of switch (trfr.moveType)
 
-		if (patch > 0  // not no-data area or matrix
+		if (dispersing==1 && // only if it is still dispersing and did not die during the last step, it should make this decision!
+            patch > 0  // not no-data area or matrix
 			&& path->total >= settsteps.minSteps) {
 			pPatch = (Patch*)patch;
 			if (pPatch != pNatalPatch)
@@ -1265,7 +1266,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	array3x3d goal;	// to hold weights for moving towards a goal location
 	array3x3f hab;	// to hold weights for habitat (includes percep range)
 	int x2, y2; 			// x index from 0=W to 2=E, y index from 0=N to 2=S
-	int newX = 0, newY = 0;
+	int newX = -9, newY = -9; // BUGFIX: must not be 0 because 0,0 is a valid landscape cell
 	Cell* pCell;
 	Cell* pNewCell = NULL;
 	double sum_nbrs = 0.0;
@@ -1428,11 +1429,12 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 			if (newX < land.minX || newX > land.maxX
 				|| newY < land.minY || newY > land.maxY) {
 				pNewCell = 0;
+			} else{
+			   pNewCell = pLand->findCell(newX, newY); // would also return 0 if outside boundary
 			}
-			pNewCell = pLand->findCell(newX, newY);
 		}
 	} while (!absorbing && pNewCell == 0 && loopsteps < 1000); // no-data cell
-	if (loopsteps >= 1000 || pNewCell == 0) {
+	if (loopsteps >= 1000 || pNewCell == 0 || (newX == -9 || newY== -9)) { // if no cell was found
 		// unable to make a move or crossed absorbing boundary
 		// flag individual to die
 		move.dist = -123.0;

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1225,7 +1225,7 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 
 		} // end of switch (trfr.moveType)
 
-		if (dispersing==1 && // only if it is still dispersing and did not die during the last step, it should make this decision!
+		if (dispersing == 1 &&
             patch > 0  // not no-data area or matrix
 			&& path->total >= settsteps.minSteps) {
 			pPatch = (Patch*)patch;


### PR DESCRIPTION
- issue: in some/rare cases individuals would jump to cell 0,0 during the SMS transfer process (Individual::smsMove())
- fix: initial values for the new location (newX and newY) now set to -9 (cell is out of boundary)
- additional: at the end of Individual::moveStep() function, the status is set to 2 for potential settlers; but this was also done for individuals dying during the current step (status==6 & dispersing == 0) -> added another condition

@TheoPannetier: Could you please recheck this fix before I merge it into main? Just to be sure...