### PR TITLE
Replace the std:queue memory used for SMS with an ad hoc implementation using a circular buffer, to reduce memory consumption.

### DIFF
--- a/Individual.cpp
+++ b/Individual.cpp
@@ -25,13 +25,75 @@
 #include "Individual.h"
 //---------------------------------------------------------------------------
 
+template <typename T>
+MemoryQueue<T>::MemoryQueue(std::size_t size):
+	space(size),
+	data(new T[size]),
+	begin_idx(0),
+	nb_elts(0)
+{ }
+
+template <typename T>
+T &MemoryQueue<T>::front() {
+	return data[begin_idx];
+}
+
+template <typename T>
+T const &MemoryQueue<T>::front() const {
+	return data[begin_idx];
+}
+
+template <typename T>
+T &MemoryQueue<T>::back() {
+	return data[(begin_idx + nb_elts - 1) % space];
+}
+
+template <typename T>
+T const &MemoryQueue<T>::back() const {
+	return data[(begin_idx + nb_elts - 1) % space];
+}
+
+template <typename T>
+void MemoryQueue<T>::push(const T& value) {
+	size_t end_idx = (begin_idx + nb_elts) % space;
+	data[end_idx] = value;
+	nb_elts++;
+}
+
+template <typename T>
+void MemoryQueue<T>::push(T&& value) {
+	size_t end_idx = (begin_idx + nb_elts) % space;
+	data[end_idx] = std::move(value);
+	nb_elts++;
+}
+
+template <typename T>
+void MemoryQueue<T>::pop() {
+	begin_idx++;
+	begin_idx %= space;
+	nb_elts--;
+}
+
+template <typename T>
+std::size_t MemoryQueue<T>::size() const {
+	return nb_elts;
+}
+
+template <typename T>
+bool MemoryQueue<T>::empty() const {
+	return nb_elts == 0;
+}
+
+//---------------------------------------------------------------------------
+
 int Individual::indCounter = 0;
 
 //---------------------------------------------------------------------------
 
 // Individual constructor
-Individual::Individual(Cell* pCell, Patch* pPatch, short stg, short a, short repInt,
-	float probmale, bool movt, short moveType)
+Individual::Individual(Species* pSpecies, Cell* pCell, Patch* pPatch, short stg, short a, short repInt,
+	float probmale, bool movt, short moveType):
+	memory(pSpecies->getSMSTraits().memSize)
 {
 	indId = indCounter;
 	indCounter++; // unique identifier for each individual
@@ -1818,6 +1880,8 @@ double cauchy(double location, double scale) {
 
 void testIndividual() {
 
+	Species* pSpecies = new Species();
+
 	Patch* pPatch = new Patch(0, 0);
 	int cell_x = 2;
 	int cell_y = 5;
@@ -1831,7 +1895,7 @@ void testIndividual() {
 	float probmale = 0;
 	bool uses_movt_process = true;
 	short moveType = 1;
-	Individual ind(pCell, pPatch, stg, age, repInt, probmale, uses_movt_process, moveType);
+	Individual ind(pSpecies, pCell, pPatch, stg, age, repInt, probmale, uses_movt_process, moveType);
 
 	// An individual can move to a neighbouring cell
 	//ind.moveto();

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -84,6 +84,11 @@ bool MemoryQueue<T>::empty() const {
 	return nb_elts == 0;
 }
 
+template <typename T>
+bool MemoryQueue<T>::full() const {
+	return nb_elts == space;
+}
+
 //---------------------------------------------------------------------------
 
 int Individual::indCounter = 0;
@@ -1506,7 +1511,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 		newcellcost = pNewCell->getCost();
 		move.cost = move.dist * 0.5f * ((float)cellcost + (float)newcellcost);
 		// make the selected move
-		if ((short)memory.size() == movt.memSize) {
+		if (memory.full()) {
 			memory.pop(); // remove oldest memory element
 		}
 		memory.push(current); // record previous location in memory

--- a/Individual.h
+++ b/Individual.h
@@ -119,6 +119,7 @@ public:
 	void pop();
 	std::size_t size() const;
 	bool empty() const;
+	bool full() const;
 };
 
 class Individual {

--- a/Individual.h
+++ b/Individual.h
@@ -47,6 +47,7 @@ Last updated: 26 October 2021 by Steve Palmer
 
 #include <queue>
 #include <algorithm>
+#include <memory>
 using namespace std;
 
 #include "Parameters.h"
@@ -99,11 +100,33 @@ struct smsdata {
 	int betaDB;			// dispersal bias decay inflection point (no. of steps)
 };
 
+// A class that mimicks std::queue with a fixed-size circular buffer.
+template <typename T>
+class MemoryQueue {
+	std::unique_ptr<T []> data;
+	const std::size_t space;
+	std::size_t begin_idx;
+	std::size_t nb_elts;
+
+public:
+	MemoryQueue(std::size_t size);
+	T &front();
+	T const &front() const;
+	T &back();
+	T const &back() const;
+	void push(const T& value);
+	void push(T&& value);
+	void pop();
+	std::size_t size() const;
+	bool empty() const;
+};
+
 class Individual {
 
 public:
 	static int indCounter; // used to create ID, held by class, not members of class
 	Individual( // Individual constructor
+		Species*, // pointer to species
 		Cell*,	// pointer to Cell
 		Patch*,	// pointer to patch
 		short,	// stage
@@ -282,7 +305,7 @@ private:
 	crwParams *crw;     				// pointer to CRW traits and data
 	smsdata *smsData;						// pointer to variables required for SMS
 	settleTraits *setttraits;		// pointer to settlement traits
-	std::queue <locn> memory;		// memory of last N squares visited for SMS
+	MemoryQueue<locn> memory;		// memory of last N squares visited for SMS
 
 	Genome *pGenome;
 

--- a/Population.cpp
+++ b/Population.cpp
@@ -176,10 +176,10 @@ Population::Population(Species* pSp, Patch* pPch, int ninds, int resol)
 			else age = stg;
 #if RSDEBUG
 			// NOTE: CURRENTLY SETTING ALL INDIVIDUALS TO RECORD NO. OF STEPS ...
-			inds.push_back(new Individual(pCell, pPatch, stg, age, sstruct.repInterval,
+			inds.push_back(new Individual(pSpecies, pCell, pPatch, stg, age, sstruct.repInterval,
 				probmale, true, trfr.moveType));
 #else
-			inds.push_back(new Individual(pCell, pPatch, stg, age, sstruct.repInterval,
+			inds.push_back(new Individual(pSpecies, pCell, pPatch, stg, age, sstruct.repInterval,
 				probmale, trfr.moveModel, trfr.moveType));
 #endif
 			sex = inds[nindivs + i]->getSex();
@@ -489,9 +489,9 @@ void Population::reproduction(const float localK, const float envval, const int 
 					for (int j = 0; j < njuvs; j++) {
 #if RSDEBUG
 						// NOTE: CURRENTLY SETTING ALL INDIVIDUALS TO RECORD NO. OF STEPS ...
-						juvs.push_back(new Individual(pCell, pPatch, 0, 0, 0, 0.0, true, trfr.moveType));
+						juvs.push_back(new Individual(pSpecies, pCell, pPatch, 0, 0, 0, 0.0, true, trfr.moveType));
 #else
-						juvs.push_back(new Individual(pCell, pPatch, 0, 0, 0, 0.0, trfr.moveModel, trfr.moveType));
+						juvs.push_back(new Individual(pSpecies, pCell, pPatch, 0, 0, 0, 0.0, trfr.moveModel, trfr.moveType));
 #endif
 						nInds[0][0]++;
 						if (emig.indVar || trfr.indVar || sett.indVar || gen.neutralMarkers)
@@ -564,9 +564,9 @@ void Population::reproduction(const float localK, const float envval, const int 
 							for (int j = 0; j < njuvs; j++) {
 #if RSDEBUG
 								// NOTE: CURRENTLY SETTING ALL INDIVIDUALS TO RECORD NO. OF STEPS ...
-								juvs.push_back(new Individual(pCell, pPatch, 0, 0, 0, dem.propMales, true, trfr.moveType));
+								juvs.push_back(new Individual(pSpecies, pCell, pPatch, 0, 0, 0, dem.propMales, true, trfr.moveType));
 #else
-								juvs.push_back(new Individual(pCell, pPatch, 0, 0, 0, dem.propMales, trfr.moveModel, trfr.moveType));
+								juvs.push_back(new Individual(pSpecies, pCell, pPatch, 0, 0, 0, dem.propMales, trfr.moveModel, trfr.moveType));
 #endif
 								sex = juvs[nj + j]->getSex();
 								nInds[0][sex]++;

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -133,7 +133,7 @@ void SubCommunity::initialInd(Landscape* pLandscape, Species* pSpecies,
 	else {
 		if (iind.sex == 1) probmale = 1.0; else probmale = 0.0;
 	}
-	pInd = new Individual(pCell, pPatch, stg, age, repInt, probmale, trfr.moveModel, trfr.moveType);
+	pInd = new Individual(pSpecies, pCell, pPatch, stg, age, repInt, probmale, trfr.moveModel, trfr.moveType);
 
 	// add new individual to the population
 	// NB THIS WILL NEED TO BE CHANGED FOR MULTIPLE SPECIES...


### PR DESCRIPTION
I’m usually not keen on replacing standard data structures with home-made ones but I think that, here, the impact is so large that it’s worth it.
On a test, that change reduced the memory usage from 1453MB to 657MB, and the simulation runtime from 196s to 180s.