### PR TITLE
OpenMP parallelization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Config file for compilation with CMake
 
-if (NOT batchmode) # that is, RScore as a standalone
+if(NOT batchmode) # that is, RScore as a standalone
 	cmake_minimum_required(VERSION 3.10)
 	# set the project name and version
 	project(RScore VERSION 2.1.0)
@@ -12,9 +12,11 @@ else() # that is, RScore compiled as library within RangeShifter_batch
 	add_library(RScore Species.cpp Cell.cpp Community.cpp FractalGenerator.cpp Genome.cpp Individual.cpp Landscape.cpp Model.cpp Parameters.cpp Patch.cpp Population.cpp RandomCheck.cpp RSrandom.cpp SubCommunity.cpp Utils.cpp)
 endif()
 
-find_package(OpenMP COMPONENTS CXX)
-if (OpenMP_CXX_FOUND)
-	target_link_libraries(RScore PUBLIC OpenMP::OpenMP_CXX)
+if(OMP)
+	find_package(OpenMP COMPONENTS CXX)
+	if(OpenMP_CXX_FOUND)
+		target_link_libraries(RScore PUBLIC OpenMP::OpenMP_CXX)
+	endif()
 endif()
 
 # pass config definitions to compiler

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ else() # that is, RScore compiled as library within RangeShifter_batch
 	add_library(RScore Species.cpp Cell.cpp Community.cpp FractalGenerator.cpp Genome.cpp Individual.cpp Landscape.cpp Model.cpp Parameters.cpp Patch.cpp Population.cpp RandomCheck.cpp RSrandom.cpp SubCommunity.cpp Utils.cpp)
 endif()
 
+find_package(OpenMP COMPONENTS CXX)
+if (OpenMP_CXX_FOUND)
+	target_link_libraries(RScore PUBLIC OpenMP::OpenMP_CXX)
+endif()
+
 # pass config definitions to compiler
 target_compile_definitions(RScore PRIVATE RSWIN64)
 
@@ -27,4 +32,4 @@ endif()
 
 if(NOT batchmode)
 	target_include_directories(RScore PUBLIC "${PROJECT_BINARY_DIR}")
-endif() 
+endif()

--- a/Cell.cpp
+++ b/Cell.cpp
@@ -147,6 +147,12 @@ float Cell::getEps(void) { return eps; }
 
 // Functions to handle costs for SMS
 
+#ifdef _OPENMP
+std::unique_lock<std::mutex> Cell::lockCost(void) {
+return std::unique_lock<std::mutex>(cost_mutex);
+}
+#endif
+
 int Cell::getCost(void) {
 int c;
 if (smsData == 0) c = 0; // costs not yet set up

--- a/Cell.cpp
+++ b/Cell.cpp
@@ -130,8 +130,8 @@ float Cell::getEps(void) { return eps; }
 // Functions to handle costs for SMS
 
 #ifdef _OPENMP
-std::unique_lock<std::mutex> Cell::lockCost(void) {
-return std::unique_lock<std::mutex>(cost_mutex);
+std::unique_lock<std::mutex> Cell::lockCost() {
+	return std::unique_lock<std::mutex>(cost_mutex);
 }
 #endif
 

--- a/Cell.h
+++ b/Cell.h
@@ -50,6 +50,11 @@ using namespace std;
 
 #include "Parameters.h"
 
+#ifdef _OPENMP
+#include <atomic>
+#include <mutex>
+#endif
+
 //---------------------------------------------------------------------------
 
 struct array3x3f { float cell[3][3]; }; 	// neighbourhood cell array (SMS)
@@ -110,6 +115,9 @@ public:
 	void setCost(
 		int		// cost value for SMS
 	);
+#ifdef _OPENMP
+	std::unique_lock<std::mutex> lockCost(void);
+#endif
 	int getCost(void);
 	void resetCost(void);
 	array3x3f getEffCosts(void);
@@ -130,13 +138,21 @@ private:
 								// gradient in K, r or extinction probability
 	float envDev;	// local environmental deviation (static, in range -1.0 to +1.0)
 	float eps;		// local environmental stochasticity (epsilon) (dynamic, from N(0,std))
+#ifdef _OPENMP
+	std::atomic<unsigned long int> visits; // no. of times square is visited by dispersers
+#else
 	unsigned long int visits; // no. of times square is visited by dispersers
+#endif
 	smscosts *smsData;
 
 	vector <short> habIxx; 		// habitat indices (rasterType=0)
 		// NB initially, habitat codes are loaded, then converted to index nos.
 		//    once landscape is fully loaded
 	vector <float> habitats;	// habitat proportions (rasterType=1) or quality (rasterType=2)
+
+#ifdef _OPENMP
+	std::mutex cost_mutex;
+#endif
 };
 
 //---------------------------------------------------------------------------

--- a/Community.cpp
+++ b/Community.cpp
@@ -397,22 +397,20 @@ void Community::patchChanges(void) {
 
 void Community::reproduction(int yr)
 {
-	float eps = 0.0; // epsilon for environmental stochasticity
 	landParams land = pLandscape->getLandParams();
 	envStochParams env = paramsStoch->getStoch();
+	float eps = 0.0; // epsilon for environmental stochasticity
+	if (env.stoch && !env.local) { // global stochasticty
+		eps = pLandscape->getGlobalStoch(yr);
+	}
 	int nsubcomms = (int)subComms.size();
 #if RSDEBUG
 	DEBUGLOG << "Community::reproduction(): this=" << this
 		<< " nsubcomms=" << nsubcomms << endl;
 #endif
 
-	#pragma omp parallel for private(eps) schedule(static,128)
+	#pragma omp parallel for shared(eps) schedule(static,128)
 	for (int i = 0; i < nsubcomms; i++) { // all sub-communities
-		if (env.stoch) {
-			if (!env.local) { // global stochasticty
-				eps = pLandscape->getGlobalStoch(yr);
-			}
-		}
 		subComms[i]->reproduction(land.resol, eps, land.rasterType, land.patchModel);
 	}
 #if RSDEBUG

--- a/Community.cpp
+++ b/Community.cpp
@@ -479,6 +479,7 @@ void Community::dispersal(short landIx)
 	// (even if not physically in the matrix)
 	int ndispersers = 0;
 	do {
+		#pragma omp parallel for schedule(static)
 		for (int i = 0; i < nsubcomms; i++) { // all populations
 			subComms[i]->resetPossSettlers();
 		}

--- a/Community.cpp
+++ b/Community.cpp
@@ -443,6 +443,7 @@ void Community::emigration(void)
 	DEBUGLOG << "Community::emigration(): this=" << this
 		<< " nsubcomms=" << nsubcomms << endl;
 #endif
+	#pragma omp parallel for schedule(static, 128)
 	for (int i = 0; i < nsubcomms; i++) { // all sub-communities
 		subComms[i]->emigration();
 	}

--- a/Community.cpp
+++ b/Community.cpp
@@ -409,7 +409,7 @@ void Community::reproduction(int yr)
 		<< " nsubcomms=" << nsubcomms << endl;
 #endif
 
-	#pragma omp parallel for shared(eps) schedule(static,128)
+	#pragma omp parallel for schedule(static,128)
 	for (int i = 0; i < nsubcomms; i++) { // all sub-communities
 		subComms[i]->reproduction(land.resol, eps, land.rasterType, land.patchModel);
 	}

--- a/Community.cpp
+++ b/Community.cpp
@@ -504,6 +504,7 @@ void Community::dispersal(short landIx)
 void Community::survival(short part, short option0, short option1)
 {
 	int nsubcomms = (int)subComms.size();
+	#pragma omp parallel for schedule(static,128)
 	for (int i = 0; i < nsubcomms; i++) { // all communities (including in matrix)
 		subComms[i]->survival(part, option0, option1);
 	}

--- a/Community.cpp
+++ b/Community.cpp
@@ -468,8 +468,17 @@ void Community::dispersal(short landIx)
 	int nsubcomms = (int)subComms.size();
 	// initiate dispersal - all emigrants leave their natal community and join matrix community
 	SubCommunity* matrix = subComms[0]; // matrix community is always the first
+	#pragma omp parallel
+	{
+	std::map<Species *,vector<Individual*>> inds_map;
+	#pragma omp for schedule(static,128) nowait
 	for (int i = 0; i < nsubcomms; i++) { // all populations
-		subComms[i]->initiateDispersal(matrix);
+		subComms[i]->initiateDispersal(inds_map);
+	}
+	for (std::pair<Species* const,std::vector<Individual*>> &item : inds_map) {
+		// add to matrix population
+		matrix->recruitMany(item.second, item.first);
+	}
 	}
 #if RSDEBUG
 	t1 = time(0);

--- a/Community.cpp
+++ b/Community.cpp
@@ -422,6 +422,7 @@ void Community::reproduction(int yr)
 		<< " nsubcomms=" << nsubcomms << endl;
 #endif
 
+	#pragma omp parallel for private(eps) schedule(static,128)
 	for (int i = 0; i < nsubcomms; i++) { // all sub-communities
 		if (env.stoch) {
 			if (!env.local) { // global stochasticty

--- a/Community.cpp
+++ b/Community.cpp
@@ -386,6 +386,7 @@ void Community::addManuallySelected(void) {
 
 void Community::resetPopns(void) {
 	int nsubcomms = (int)subComms.size();
+	#pragma omp parallel for schedule(static,128)
 	for (int i = 0; i < nsubcomms; i++) { // all sub-communities
 		subComms[i]->resetPopns();
 	}

--- a/Community.cpp
+++ b/Community.cpp
@@ -469,17 +469,17 @@ void Community::dispersal(short landIx)
 	int nsubcomms = (int)subComms.size();
 	// initiate dispersal - all emigrants leave their natal community and join matrix community
 	SubCommunity* matrix = subComms[0]; // matrix community is always the first
-	#pragma omp parallel
+#pragma omp parallel
 	{
-	std::map<Species *,vector<Individual*>> inds_map;
-	#pragma omp for schedule(static,128) nowait
-	for (int i = 0; i < nsubcomms; i++) { // all populations
-		subComms[i]->initiateDispersal(inds_map);
-	}
-	for (std::pair<Species* const,std::vector<Individual*>> &item : inds_map) {
-		// add to matrix population
-		matrix->recruitMany(item.second, item.first);
-	}
+		std::map<Species*, vector<Individual*>> inds_map;
+#pragma omp for schedule(static,128) nowait
+		for (int i = 0; i < nsubcomms; i++) { // all populations
+			subComms[i]->initiateDispersal(inds_map);
+		}
+		for (std::pair<Species* const, std::vector<Individual*>>& item : inds_map) {
+			// add to matrix population
+			matrix->recruitMany(item.second, item.first);
+		}
 	}
 #if RSDEBUG
 	t1 = time(0);

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -25,7 +25,11 @@
 #include "Individual.h"
 //---------------------------------------------------------------------------
 
+#ifdef _OPENMP
+std::atomic<int> Individual::indCounter = 0;
+#else // _OPENMP
 int Individual::indCounter = 0;
+#endif // _OPENMP
 
 //---------------------------------------------------------------------------
 
@@ -33,8 +37,7 @@ int Individual::indCounter = 0;
 Individual::Individual(Cell* pCell, Patch* pPatch, short stg, short a, short repInt,
 	float probmale, bool movt, short moveType)
 {
-	indId = indCounter;
-	indCounter++; // unique identifier for each individual
+	indId = indCounter++; // unique identifier for each individual
 
 	stage = stg;
 	if (probmale <= 0.0) sex = 0;

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -23,6 +23,13 @@
  //---------------------------------------------------------------------------
 
 #include "Individual.h"
+
+#if RS_RCPP
+#ifdef _OMPENMP
+#include <mutex>
+#endif
+#endif
+
 //---------------------------------------------------------------------------
 
 #ifdef _OPENMP
@@ -1742,6 +1749,10 @@ void Individual::outGenetics(const int rep, const int year, const int spnum,
 }
 
 #if RS_RCPP
+#ifdef _OMPENMP
+std::mutex outMovePaths_mutex;
+#endif
+
 //---------------------------------------------------------------------------
 // Write records to movement paths file
 void Individual::outMovePath(const int year)
@@ -1750,6 +1761,9 @@ void Individual::outMovePath(const int year)
 
 	//if (pPatch != pNatalPatch) {
 	loc = pCurrCell->getLocn();
+#ifdef _OMPENMP
+	const std::lock_guard<std::mutex> lock(outMovePaths_mutex);
+#endif
 	// if still dispersing...
 	if (status == 1) {
 		// at first step, record start cell first

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -24,10 +24,8 @@
 
 #include "Individual.h"
 
-#if RS_RCPP
-#ifdef _OMPENMP
+#ifdef _OPENMP
 #include <mutex>
-#endif
 #endif
 
 //---------------------------------------------------------------------------
@@ -1816,7 +1814,7 @@ void Individual::outGenetics(const int rep, const int year, const int spnum,
 }
 
 #if RS_RCPP
-#ifdef _OMPENMP
+#ifdef _OPENMP
 std::mutex outMovePaths_mutex;
 #endif
 
@@ -1828,7 +1826,7 @@ void Individual::outMovePath(const int year)
 
 	//if (pPatch != pNatalPatch) {
 	loc = pCurrCell->getLocn();
-#ifdef _OMPENMP
+#ifdef _OPENMP
 	const std::lock_guard<std::mutex> lock(outMovePaths_mutex);
 #endif
 	// if still dispersing...

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1326,7 +1326,10 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 
 	// get habitat-dependent weights (mean effective costs, given perceptual range)
 	// first check if costs have already been calculated
-
+	{
+#ifdef _OPENMP
+	const std::unique_lock<std::mutex> lock = pCurrCell->lockCost();
+#endif
 	hab = pCurrCell->getEffCosts();
 
 	if (hab.cell[0][0] < 0.0) { // costs have not already been calculated
@@ -1336,6 +1339,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	}
 	else {
 		// they have already been calculated - no action required
+	}
 	}
 
 	// determine weighted effective cost for the 8 neighbours

--- a/Individual.h
+++ b/Individual.h
@@ -56,6 +56,10 @@ using namespace std;
 #include "Cell.h"
 #include "Genome.h"
 
+#ifdef _OPENMP
+#include <atomic>
+#endif // _OPENMP
+
 #define NODATACOST 100000 // cost to use in place of nodata value for SMS
 #define ABSNODATACOST 100 // cost to use in place of nodata value for SMS
 													// when boundaries are absorbing
@@ -102,7 +106,11 @@ struct smsdata {
 class Individual {
 
 public:
+#ifdef _OPENMP
+	static std::atomic<int> indCounter; // used to create ID, held by class, not members of class
+#else
 	static int indCounter; // used to create ID, held by class, not members of class
+#endif
 	Individual( // Individual constructor
 		Cell*,	// pointer to Cell
 		Patch*,	// pointer to patch

--- a/Patch.cpp
+++ b/Patch.cpp
@@ -304,8 +304,8 @@ intptr Patch::getSubComm(void)
 { return subCommPtr; }
 
 #ifdef _OPENMP
-std::unique_lock<std::mutex> Patch::lockPopns(void) {
-return std::unique_lock<std::mutex>(popns_mutex);
+std::unique_lock<std::mutex> Patch::lockPopns() {
+	return std::unique_lock<std::mutex>(popns_mutex);
 }
 #endif
 

--- a/Patch.cpp
+++ b/Patch.cpp
@@ -303,6 +303,12 @@ void Patch::setSubComm(intptr sc)
 intptr Patch::getSubComm(void)
 { return subCommPtr; }
 
+#ifdef _OPENMP
+std::unique_lock<std::mutex> Patch::lockPopns(void) {
+return std::unique_lock<std::mutex>(popns_mutex);
+}
+#endif
+
 void Patch::addPopn(patchPopn pop) {
 popns.push_back(pop);
 }

--- a/Patch.h
+++ b/Patch.h
@@ -74,6 +74,7 @@ using namespace std;
 
 #ifdef _OPENMP
 #include <atomic>
+#include <mutex>
 #endif
 
 //---------------------------------------------------------------------------
@@ -119,6 +120,9 @@ public:
 		intptr		// pointer to the Sub-community cast as an integer
 	);
 	intptr getSubComm(void);
+#ifdef _OPENMP
+	std::unique_lock<std::mutex> lockPopns(void);
+#endif
 	void addPopn(
 		patchPopn // structure holding pointers to Species and Population cast as integers
 	);
@@ -168,6 +172,9 @@ public:
 	std::vector <Cell*> cells;
 	std::vector <patchPopn> popns;
 
+#ifdef _OPENMP
+	std::mutex popns_mutex;
+#endif
 };
 
 //---------------------------------------------------------------------------

--- a/Patch.h
+++ b/Patch.h
@@ -72,6 +72,10 @@ using namespace std;
 #include "Cell.h"
 #include "Species.h"
 
+#ifdef _OPENMP
+#include <atomic>
+#endif
+
 //---------------------------------------------------------------------------
 
 struct patchLimits {
@@ -155,7 +159,11 @@ public:
 	float localK;		// patch carrying capacity (individuals)
 	bool changed;
 // NOTE: THE FOLLOWING ARRAY WILL NEED TO BE MADE SPECIES-SPECIFIC...
+#ifdef _OPENMP
+	std::atomic<short> nTemp[NSEXES];						// no. of potential settlers in each sex
+#else
 	short nTemp[NSEXES];						// no. of potential settlers in each sex
+#endif
 
 	std::vector <Cell*> cells;
 	std::vector <patchPopn> popns;

--- a/Patch.h
+++ b/Patch.h
@@ -121,7 +121,7 @@ public:
 	);
 	intptr getSubComm(void);
 #ifdef _OPENMP
-	std::unique_lock<std::mutex> lockPopns(void);
+	std::unique_lock<std::mutex> lockPopns();
 #endif
 	void addPopn(
 		patchPopn // structure holding pointers to Species and Population cast as integers

--- a/Population.cpp
+++ b/Population.cpp
@@ -812,6 +812,20 @@ void Population::recruit(Individual* pInd) {
 	inds.push_back(pInd);
 }
 
+// Add specified individuals to the new/current dispersal group
+// Add specified individuals to the population
+void Population::recruitMany(std::vector<Individual*>& new_inds) {
+	if (new_inds.empty()) return;
+	for (Individual* pInd : new_inds) {
+		indStats ind = pInd->getStats();
+		nInds[ind.stage][ind.sex]++;
+	}
+#ifdef _OPENMP
+	const std::lock_guard<std::mutex> lock(inds_mutex);
+#endif // _OPENMP
+	inds.insert(inds.end(), new_inds.begin(), new_inds.end());
+}
+
 //---------------------------------------------------------------------------
 
 // Transfer is run for populations in the matrix only

--- a/Population.cpp
+++ b/Population.cpp
@@ -872,6 +872,7 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 	}
 
 // each individual which has reached a potential patch decides whether to settle
+	#pragma omp parallel for reduction(-:ndispersers) default(none) shared(ninds, settletype, pRandom, trfr, ppLand, pLandscape) private(ind, othersex, sett, pCell, mateOK, densdepOK, settle, patch, pPatch, localK, popn, popsize, pNewPopn, settDD, settprob, newloc, nbrloc, patchnum) schedule(static)
 	for (int i = 0; i < ninds; i++) {
 		ind = inds[i]->getStats();
 		if (ind.sex == 0) othersex = 1; else othersex = 0;

--- a/Population.cpp
+++ b/Population.cpp
@@ -843,6 +843,7 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 	// each individual takes one step
 	// for dispersal by kernel, this should be the only step taken
 	int ninds = (int)inds.size();
+	#pragma omp parallel for reduction(+:ndispersers) private(disperser, pCell, pPatch, patch) schedule(static,128)
 	for (int i = 0; i < ninds; i++) {
 		if (trfr.moveModel) {
 			disperser = inds[i]->moveStep(pLandscape, pSpecies, landIx, sim.absorbing);

--- a/Population.cpp
+++ b/Population.cpp
@@ -804,9 +804,12 @@ disperser Population::extractSettler(int ix) {
 // Add a specified individual to the new/current dispersal group
 // Add a specified individual to the population
 void Population::recruit(Individual* pInd) {
-	inds.push_back(pInd);
 	indStats ind = pInd->getStats();
 	nInds[ind.stage][ind.sex]++;
+#ifdef _OPENMP
+	const std::lock_guard<std::mutex> lock(inds_mutex);
+#endif // _OPENMP
+	inds.push_back(pInd);
 }
 
 //---------------------------------------------------------------------------

--- a/Population.h
+++ b/Population.h
@@ -150,6 +150,9 @@ public:
 	void recruit( // Add a specified individual to the population
 		Individual*	// pointer to Individual
 	);
+	void recruitMany( // Add specified individuals to the population
+		std::vector<Individual*>&	// vector of pointers to Individuals
+	);
 #if RS_RCPP
 	int transfer( // Executed for the Population(s) in the matrix only
 		Landscape*,	// pointer to Landscape

--- a/Population.h
+++ b/Population.h
@@ -59,6 +59,11 @@ using namespace std;
 #include "Patch.h"
 #include "Cell.h"
 
+#ifdef _OPENMP
+#include <atomic>
+#include <mutex>
+#endif
+
 //---------------------------------------------------------------------------
 
 struct popStats {
@@ -220,12 +225,18 @@ private:
 	short nSexes;
 	Species *pSpecies;	// pointer to the species
 	Patch *pPatch;			// pointer to the patch
+#ifdef _OPENMP
+	std::atomic<int> nInds[NSTAGES][NSEXES];		// no. of individuals in each stage/sex
+#else
 	int nInds[NSTAGES][NSEXES];		// no. of individuals in each stage/sex
+#endif // _OPENMP
 
 	std::vector <Individual*> inds; // all individuals in population except ...
 	std::vector <Individual*> juvs; // ... juveniles until reproduction of ALL species
 																	// has been completed
-
+#ifdef _OPENMP
+	std::mutex inds_mutex;
+#endif // _OPENMP
 };
 
 //---------------------------------------------------------------------------

--- a/RSrandom.h
+++ b/RSrandom.h
@@ -39,6 +39,7 @@ Last updated: 12 January 2021 by Steve Palmer
 #include <stdlib.h>
 #include <fstream>
 #include <cassert>
+#include <vector>
 #include "Utils.h"
 
 using namespace std;
@@ -69,7 +70,7 @@ extern ofstream DEBUGLOG;
 		mt19937 getRNG(void);
 
 	private:
-		mt19937* gen;
+		std::vector<mt19937> gens;
 		std::uniform_real_distribution<>* pRandom01;
 		std::normal_distribution<>* pNormal;
 	};

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -299,8 +299,8 @@ void SubCommunity::emigration(void)
 	}
 }
 
-// Remove emigrants from their natal patch and add to patch 0 (matrix)
-void SubCommunity::initiateDispersal(SubCommunity* matrix) {
+// Remove emigrants from their natal patch and add to a map of vectors
+void SubCommunity::initiateDispersal(std::map<Species*,std::vector<Individual *>> &inds_map) {
 	if (subCommNum == 0) return; // no dispersal initiation in the matrix
 	popStats pop;
 	disperser disp;
@@ -308,11 +308,11 @@ void SubCommunity::initiateDispersal(SubCommunity* matrix) {
 	int npops = (int)popns.size();
 	for (int i = 0; i < npops; i++) { // all populations
 		pop = popns[i]->getStats();
+		Species* pSpecies = popns[i]->getSpecies();
 		for (int j = 0; j < pop.nInds; j++) {
 			disp = popns[i]->extractDisperser(j);
 			if (disp.yes) { // disperser - has already been removed from natal population
-				// add to matrix population
-				matrix->recruit(disp.pInd, pop.pSpecies);
+				inds_map[pSpecies].push_back(disp.pInd);
 			}
 		}
 		// remove pointers to emigrants
@@ -327,6 +327,16 @@ void SubCommunity::recruit(Individual* pInd, Species* pSpecies) {
 	for (int i = 0; i < npops; i++) { // all populations
 		if (pSpecies == popns[i]->getSpecies()) {
 			popns[i]->recruit(pInd);
+		}
+	}
+}
+
+// Add individuals into the local population of their species in the patch
+void SubCommunity::recruitMany(std::vector<Individual*>& inds, Species* pSpecies) {
+	int npops = (int)popns.size();
+	for (int i = 0; i < npops; i++) { // all populations
+		if (pSpecies == popns[i]->getSpecies()) {
+			popns[i]->recruitMany(inds);
 		}
 	}
 }

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -48,6 +48,7 @@ Last updated: 26 October 2021 by Steve Palmer
 
 #include <vector>
 #include <algorithm>
+#include <map>
 using namespace std;
 
 #include "Parameters.h"
@@ -94,13 +95,18 @@ public:
 		bool		// TRUE for a patch-based model, FALSE for a cell-based model
 	);
 	void emigration(void);
-	// Remove emigrants from their natal patch and add to patch 0 (matrix)
+	// Remove emigrants from their natal patch and add to a map of vectors
 	void initiateDispersal(
-		SubCommunity*	// pointer to matrix SubCommunity
+		std::map<Species*,std::vector<Individual*>>&
 	);
 // Add an individual into the local population of its species in the patch
 	void recruit(
 		Individual*,	// pointer to Individual
+		Species*			// pointer to Species
+	);
+// Add individuals into the local population of their species in the patch
+	void recruitMany(
+		std::vector<Individual*>&,	// vector of pointers to Individuals
 		Species*			// pointer to Species
 	);
 #if RS_RCPP


### PR DESCRIPTION
I did my best to run RangeShifter in OpenMP parallel loops, except for file writing.
I tried to identify all possible race conditions and to handle them by using either atomics or mutexes.

A test, **run with a single thread**, shows that the results of the simulation are not affected by those changes, but there is some overhead: the runtime raises from 185s to 201s, and the memory footprint from 605MB to 655MB.
When I run the same test with 4 threads, the runtime drops to 78s and the memory footprint raises to 657MB.

Note that the results of the simulation vary with the number of threads as it changes the distribution of pseudo-random numbers.
They also vary between runs with the same number of threads (unless there is only one thread) because of races between threads:

- to get identifiers for new individuals in the `reproduction` stage,
- to recruit individuals into the matrix in the `initiateDispersal` stage,
- to recruit individuals into patches in the `completeDispersal` stage.

Because of the overhead, you might want to add a compilation option to disable OpenMP parallelization.
You may also want to add code (possibly in the front-ends) to choose the number of threads to use. By default, OpenMP uses as many threads as cores it can use. For the batch front-end, it is easy to change, by setting the `OMP_NUM_THREADS` environment variable.

Any comment/suggestion/question is welcome.