### PR TITLE
Avoid conversion of intptr to pointers

### DIFF
--- a/Cell.cpp
+++ b/Cell.cpp
@@ -30,7 +30,7 @@
 
 // Cell functions
 
-Cell::Cell(int xx,int yy,intptr patch,int hab)
+Cell::Cell(int xx,int yy,Patch *patch,int hab)
 {
 x = xx; y = yy;
 pPatch = patch;
@@ -41,7 +41,7 @@ visits = 0;
 smsData = 0;
 }
 
-Cell::Cell(int xx,int yy,intptr patch,float hab)
+Cell::Cell(int xx,int yy,Patch *patch,float hab)
 {
 x = xx; y = yy;
 pPatch = patch;
@@ -101,10 +101,10 @@ if (ix < 0 || ix >= (int)habitats.size())
 else return habitats[ix];
 }
 
-void Cell::setPatch(intptr p) {
+void Cell::setPatch(Patch *p) {
 pPatch = p;
 }
-intptr Cell::getPatch(void)
+Patch *Cell::getPatch(void)
 {
 return pPatch;
 }

--- a/Cell.h
+++ b/Cell.h
@@ -52,6 +52,8 @@ using namespace std;
 
 //---------------------------------------------------------------------------
 
+class Patch; // Forward-declaration of the Patch class
+
 struct array3x3f { float cell[3][3]; }; 	// neighbourhood cell array (SMS)
 struct smscosts { int cost; array3x3f *effcosts; };	// cell costs for SMS
 
@@ -62,13 +64,13 @@ public:
 	Cell( // Constructor for habitat codes
 		int,				// x co-ordinate
 		int,				// y co-ordinate
-		intptr,			// pointer (cast as integer) to the Patch to which Cell belongs
+		Patch *,			// pointer to the Patch to which Cell belongs
 		int					// habitat index number
 	);
 	Cell( // Constructor for habitat % cover or habitat quality
 		int,				// x co-ordinate
 		int,				// y co-ordinate
-		intptr,			// pointer (cast as integer) to the Patch to which Cell belongs
+		Patch *,			// pointer to the Patch to which Cell belongs
 		float				// habitat proportion or cell quality score
 	);
 	~Cell();
@@ -90,9 +92,9 @@ public:
 		int		// habitat index number / landscape change number
 	);
 	void setPatch(
-		intptr		// pointer (cast as integer) to the Patch to which Cell belongs
+		Patch *		// pointer to the Patch to which Cell belongs
 	);
-	intptr getPatch(void);
+	Patch *getPatch(void);
 	locn getLocn(void);
 	void setEnvDev(
 		float	// local environmental deviation
@@ -123,7 +125,7 @@ public:
 
 private:
 	int x,y;			// cell co-ordinates
-	intptr pPatch; 	// pointer (cast as integer) to the Patch to which cell belongs
+	Patch *pPatch; 	// pointer to the Patch to which cell belongs
 	// NOTE: THE FOLLOWING ENVIRONMENTAL VARIABLES COULD BE COMBINED IN A STRUCTURE
 	// AND ACCESSED BY A POINTER ...
 	float envVal; // environmental value, representing one of:

--- a/Community.cpp
+++ b/Community.cpp
@@ -59,8 +59,7 @@ void Community::initialise(Species* pSpecies, int year)
 	locn distloc;
 	patchData pch;
 	patchLimits limits;
-	intptr subcomm;
-	std::vector <intptr> subcomms;
+	std::vector <SubCommunity *> subcomms;
 	std::vector <bool> selected;
 	SubCommunity* pSubComm;
 	Patch* pPatch;
@@ -138,7 +137,7 @@ void Community::initialise(Species* pSpecies, int year)
 			}
 			for (int i = 0; i < npatches; i++) {
 				if (selected[i]) {
-					pSubComm = (SubCommunity*)subcomms[i];
+					pSubComm = subcomms[i];
 					pSubComm->setInitial(true);
 				}
 			}
@@ -155,13 +154,10 @@ void Community::initialise(Species* pSpecies, int year)
 					if (patchnum != 0) {
 						if (pch.pPatch->getK() > 0.0)
 						{ // patch is suitable
-							subcomm = pch.pPatch->getSubComm();
-							if (subcomm == 0) {
+							pSubComm = pch.pPatch->getSubComm();
+							if (pSubComm == nullptr) {
 								// create a sub-community in the patch
 								pSubComm = addSubComm(pch.pPatch, patchnum);
-							}
-							else {
-								pSubComm = (SubCommunity*)subcomm;
 							}
 							pSubComm->setInitial(true);
 						}
@@ -214,9 +210,8 @@ void Community::initialise(Species* pSpecies, int year)
 								pPatch = pCell->getPatch();
 								if (pPatch != nullptr) {
 									if (pPatch->getSeqNum() != 0) { // not the matrix patch
-										subcomm = pPatch->getSubComm();
-										if (subcomm != 0) {
-											pSubComm = (SubCommunity*)subcomm;
+										pSubComm = pPatch->getSubComm();
+										if (pSubComm != nullptr) {
 											pSubComm->setInitial(true);
 										}
 									}
@@ -255,13 +250,10 @@ void Community::initialise(Species* pSpecies, int year)
 							pPatch = pLandscape->findPatch(iind.patchID);
 							if (pPatch->getK() > 0.0)
 							{ // patch is suitable
-								subcomm = pPatch->getSubComm();
-								if (subcomm == 0) {
+								pSubComm = pPatch->getSubComm();
+								if (pSubComm == nullptr) {
 									// create a sub-community in the patch
 									pSubComm = addSubComm(pPatch, iind.patchID);
-								}
-								else {
-									pSubComm = (SubCommunity*)subcomm;
 								}
 								pSubComm->initialInd(pLandscape, pSpecies, pPatch, pPatch->getRandomCell(), indIx);
 							}
@@ -274,13 +266,10 @@ void Community::initialise(Species* pSpecies, int year)
 							if (pPatch != nullptr) {
 								if (pPatch->getK() > 0.0)
 								{ // patch is suitable
-									subcomm = pPatch->getSubComm();
-									if (subcomm == 0) {
+									pSubComm = pPatch->getSubComm();
+									if (pSubComm == nullptr) {
 										// create a sub-community in the patch
 										pSubComm = addSubComm(pPatch, iind.patchID);
-									}
-									else {
-										pSubComm = (SubCommunity*)subcomm;
 									}
 									pSubComm->initialInd(pLandscape, pSpecies, pPatch, pCell, indIx);
 								}
@@ -317,7 +306,6 @@ void Community::initialise(Species* pSpecies, int year)
 // Add manually selected patches/cells to the selected set for initialisation
 void Community::addManuallySelected(void) {
 	int npatches;
-	intptr subcomm;
 	locn initloc;
 	Cell* pCell;
 	Patch* pPatch;
@@ -336,9 +324,8 @@ void Community::addManuallySelected(void) {
 			initloc = pLandscape->getInitCell(i); // patch number held in x-coord of list
 			pPatch = pLandscape->findPatch(initloc.x);
 			if (pPatch != 0) {
-				subcomm = pPatch->getSubComm();
-				if (subcomm != 0) {
-					pSubComm = (SubCommunity*)subcomm;
+				pSubComm = pPatch->getSubComm();
+				if (pSubComm != nullptr) {
 					pSubComm->setInitial(true);
 				}
 			}
@@ -359,14 +346,13 @@ void Community::addManuallySelected(void) {
 						<< endl;
 #endif
 					if (pPatch != nullptr) {
-						subcomm = pPatch->getSubComm();
+						pSubComm = pPatch->getSubComm();
 #if RSDEBUG
 						DEBUGLOG << "Community::initialise(): i = " << i
-							<< " pPatch = " << pPatch << " subcomm = " << subcomm
+							<< " pPatch = " << pPatch << " subcomm = " << (intptr)pSubComm
 							<< endl;
 #endif
-						if (subcomm != 0) {
-							pSubComm = (SubCommunity*)subcomm;
+						if (pSubComm != nullptr) {
 							pSubComm->setInitial(true);
 #if RSDEBUG
 							DEBUGLOG << "Community::initialise(): i = " << i
@@ -1513,8 +1499,7 @@ Rcpp::IntegerMatrix Community::addYearToPopList(int rep, int yr) {  // TODO: def
 	landParams ppLand = pLandscape->getLandParams();
 	Rcpp::IntegerMatrix pop_map_year(ppLand.dimY, ppLand.dimX);
 	Patch* pPatch = 0;
-	intptr subcomm = 0;
-	SubCommunity* pSubComm = 0;
+	SubCommunity* pSubComm = nullptr;
 	popStats pop;
 	pop.nInds = pop.nAdults = pop.nNonJuvs = 0;
 
@@ -1530,12 +1515,11 @@ Rcpp::IntegerMatrix Community::addYearToPopList(int rep, int yr) {  // TODO: def
 					pop_map_year(ppLand.dimY - 1 - y, x) = 0;
 				}
 				else {
-					subcomm = pPatch->getSubComm();
-					if (subcomm == 0) { // check if sub-community exists
+					pSubComm = pPatch->getSubComm();
+					if (pSubComm == nullptr) { // check if sub-community exists
 						pop_map_year(ppLand.dimY - 1 - y, x) = 0;
 					}
 					else {
-						pSubComm = (SubCommunity*)subcomm;
 						pop = pSubComm->getPopStats();
 						pop_map_year(ppLand.dimY - 1 - y, x) = pop.nInds; // use indices like this because matrix gets transposed upon casting it into a raster on R-level
 					}

--- a/Community.cpp
+++ b/Community.cpp
@@ -59,7 +59,7 @@ void Community::initialise(Species* pSpecies, int year)
 	locn distloc;
 	patchData pch;
 	patchLimits limits;
-	intptr ppatch, subcomm;
+	intptr subcomm;
 	std::vector <intptr> subcomms;
 	std::vector <bool> selected;
 	SubCommunity* pSubComm;
@@ -211,9 +211,8 @@ void Community::initialise(Species* pSpecies, int year)
 						for (int y = 0; y < spratio; y++) {
 							pCell = pLandscape->findCell(distloc.x * spratio + x, distloc.y * spratio + y);
 							if (pCell != 0) { // not a no-data cell
-								ppatch = pCell->getPatch();
-								if (ppatch != 0) {
-									pPatch = (Patch*)ppatch;
+								pPatch = pCell->getPatch();
+								if (pPatch != nullptr) {
 									if (pPatch->getSeqNum() != 0) { // not the matrix patch
 										subcomm = pPatch->getSubComm();
 										if (subcomm != 0) {
@@ -271,9 +270,8 @@ void Community::initialise(Species* pSpecies, int year)
 					else { // cell-based model
 						pCell = pLandscape->findCell(iind.x, iind.y);
 						if (pCell != 0) {
-							intptr ppatch = pCell->getPatch();
-							if (ppatch != 0) {
-								pPatch = (Patch*)ppatch;
+							pPatch = pCell->getPatch();
+							if (pPatch != nullptr) {
 								if (pPatch->getK() > 0.0)
 								{ // patch is suitable
 									subcomm = pPatch->getSubComm();
@@ -319,7 +317,7 @@ void Community::initialise(Species* pSpecies, int year)
 // Add manually selected patches/cells to the selected set for initialisation
 void Community::addManuallySelected(void) {
 	int npatches;
-	intptr subcomm, patch;
+	intptr subcomm;
 	locn initloc;
 	Cell* pCell;
 	Patch* pPatch;
@@ -353,15 +351,14 @@ void Community::addManuallySelected(void) {
 				&& initloc.y >= 0 && initloc.y < ppLand.dimY) {
 				pCell = pLandscape->findCell(initloc.x, initloc.y);
 				if (pCell != 0) { // not no-data cell
-					patch = pCell->getPatch();
+					pPatch = pCell->getPatch();
 #if RSDEBUG
 					DEBUGLOG << "Community::initialise(): i = " << i
 						<< " x = " << initloc.x << " y = " << initloc.y
-						<< " pCell = " << pCell << " patch = " << patch
+						<< " pCell = " << pCell << " patch = " << (intptr)pPatch
 						<< endl;
 #endif
-					if (patch != 0) {
-						pPatch = (Patch*)patch;
+					if (pPatch != nullptr) {
 						subcomm = pPatch->getSubComm();
 #if RSDEBUG
 						DEBUGLOG << "Community::initialise(): i = " << i
@@ -1515,7 +1512,6 @@ Rcpp::IntegerMatrix Community::addYearToPopList(int rep, int yr) {  // TODO: def
 
 	landParams ppLand = pLandscape->getLandParams();
 	Rcpp::IntegerMatrix pop_map_year(ppLand.dimY, ppLand.dimX);
-	intptr patch = 0;
 	Patch* pPatch = 0;
 	intptr subcomm = 0;
 	SubCommunity* pSubComm = 0;
@@ -1529,12 +1525,11 @@ Rcpp::IntegerMatrix Community::addYearToPopList(int rep, int yr) {  // TODO: def
 				pop_map_year(ppLand.dimY - 1 - y, x) = NA_INTEGER;
 			}
 			else {
-				patch = pCell->getPatch();
-				if (patch == 0) { // matrix cell
+				pPatch = pCell->getPatch();
+				if (pPatch == nullptr) { // matrix cell
 					pop_map_year(ppLand.dimY - 1 - y, x) = 0;
 				}
 				else {
-					pPatch = (Patch*)patch;
 					subcomm = pPatch->getSubComm();
 					if (subcomm == 0) { // check if sub-community exists
 						pop_map_year(ppLand.dimY - 1 - y, x) = 0;

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -935,7 +935,6 @@ int Individual::moveKernel(Landscape* pLandscape, Species* pSpecies,
 	const short repType, const bool absorbing)
 {
 
-	intptr patch;
 	int patchNum = 0;
 	int newX = 0, newY = 0;
 	int dispersing = 1;
@@ -1042,30 +1041,28 @@ int Individual::moveKernel(Landscape* pLandscape, Species* pSpecies,
 				if (newX < land.minX || newX > land.maxX
 					|| newY < land.minY || newY > land.maxY) { // beyond absorbing boundary
 					pCell = 0;
-					patch = 0;
+					pPatch = nullptr;
 					patchNum = -1;
 				}
 				else {
 					pCell = pLandscape->findCell(newX, newY);
 					if (pCell == 0) { // no-data cell
-						patch = 0;
+						pPatch = nullptr;
 						patchNum = -1;
 					}
 					else {
-						patch = pCell->getPatch();
-						if (patch == 0) { // matrix
-							pPatch = 0;
+						pPatch = pCell->getPatch();
+						if (pPatch == nullptr) { // matrix
 							patchNum = 0;
 						}
 						else {
-							pPatch = (Patch*)patch;
 							patchNum = pPatch->getPatchNum();
 						}
 					}
 				}
 			}
 			else {
-				patch = 0;
+				pPatch = nullptr;
 				patchNum = -1;
 			}
 		} while (!absorbing && patchNum < 0 && loopsteps < 1000); 			 // in a no-data region
@@ -1134,7 +1131,6 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 
 	if (status != 1) return 0; // not currently dispersing
 
-	intptr patch;
 	int patchNum;
 	int newX, newY;
 	locn loc;
@@ -1143,7 +1139,7 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 	double angle;
 	double mortprob, rho, steplen;
 	movedata move;
-	Patch* pPatch = 0;
+	Patch* pPatch = nullptr;
 	bool absorbed = false;
 
 	landData land = pLandscape->getLandData();
@@ -1153,14 +1149,12 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 	trfrCRWTraits movt = pSpecies->getCRWTraits();
 	settleSteps settsteps = pSpecies->getSteps(stage, sex);
 
-	patch = pCurrCell->getPatch();
+	pPatch = pCurrCell->getPatch();
 
-	if (patch == 0) { // matrix
-		pPatch = 0;
+	if (pPatch == nullptr) { // matrix
 		patchNum = 0;
 	}
 	else {
-		pPatch = (Patch*)patch;
 		patchNum = pPatch->getPatchNum();
 	}
 	// apply step-dependent mortality risk ...
@@ -1184,7 +1178,7 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 	else { // take a step
 		(path->year)++;
 		(path->total)++;
-		if (patch == 0 || pPatch == 0 || patchNum == 0) { // not in a patch
+		if (pPatch == nullptr || patchNum == 0) { // not in a patch
 			if (path != 0) path->settleStatus = 0; // reset path settlement status
 			(path->out)++;
 		}
@@ -1207,13 +1201,7 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 
 				// WOULD IT BE MORE EFFICIENT FOR smsMove TO RETURN A POINTER TO THE NEW CELL? ...
 
-				patch = pCurrCell->getPatch();
-				if (patch == 0) {
-					pPatch = 0;
-				}
-				else {
-					pPatch = (Patch*)patch;
-				}
+				pPatch = pCurrCell->getPatch();
 				if (sim.saveVisits && pPatch != pNatalPatch) {
 					pCurrCell->incrVisits();
 				}
@@ -1264,11 +1252,11 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 				else
 					pCurrCell = pLandscape->findCell(newX, newY);
 				if (pCurrCell == 0) { // no-data cell or beyond absorbing boundary
-					patch = 0;
+					pPatch = nullptr;
 					if (absorbing) absorbed = true;
 				}
 				else
-					patch = pCurrCell->getPatch();
+					pPatch = pCurrCell->getPatch();
 			} while (!absorbing && pCurrCell == 0 && loopsteps < 1000);
 			crw->prevdrn = (float)angle;
 			crw->xc = (float)xcnew; crw->yc = (float)ycnew;
@@ -1293,9 +1281,8 @@ int Individual::moveStep(Landscape* pLandscape, Species* pSpecies,
 		} // end of switch (trfr.moveType)
 
 		if (dispersing == 1 &&
-            patch > 0  // not no-data area or matrix
+            pPatch != nullptr  // not no-data area or matrix
 			&& path->total >= settsteps.minSteps) {
-			pPatch = (Patch*)patch;
 			if (pPatch != pNatalPatch)
 			{
 				// determine whether the new patch is potentially suitable
@@ -1891,7 +1878,7 @@ void testIndividual() {
 	int cell_x = 2;
 	int cell_y = 5;
 	int cell_hab = 2;
-	Cell* pCell = new Cell(cell_x, cell_y, (intptr)pPatch, cell_hab);
+	Cell* pCell = new Cell(cell_x, cell_y, pPatch, cell_hab);
 
 	// Create an individual
 	short stg = 0;

--- a/Landscape.cpp
+++ b/Landscape.cpp
@@ -771,7 +771,7 @@ void Landscape::addNewCellToPatch(Patch* pPatch, int x, int y, float q) {
 		cells[y][x] = 0;
 	}
 	else { // create the new cell
-		cells[y][x] = new Cell(x, y, (intptr)pPatch, q);
+		cells[y][x] = new Cell(x, y, pPatch, q);
 		if (pPatch != 0) { // not the matrix patch
 			// add the cell to the patch
 			pPatch->addCell(cells[y][x], x, y);
@@ -783,7 +783,7 @@ void Landscape::addNewCellToPatch(Patch* pPatch, int x, int y, int hab) {
 	if (hab < 0) // no-data cell - no Cell created
 		cells[y][x] = 0;
 	else { // create the new cell
-		cells[y][x] = new Cell(x, y, (intptr)pPatch, hab);
+		cells[y][x] = new Cell(x, y, pPatch, hab);
 		if (pPatch != 0) { // not the matrix patch
 			// add the cell to the patch
 			pPatch->addCell(cells[y][x], x, y);
@@ -792,14 +792,14 @@ void Landscape::addNewCellToPatch(Patch* pPatch, int x, int y, int hab) {
 }
 
 void Landscape::addCellToPatch(Cell* pCell, Patch* pPatch) {
-	pCell->setPatch((intptr)pPatch);
+	pCell->setPatch(pPatch);
 	locn loc = pCell->getLocn();
 	// add the cell to the patch
 	pPatch->addCell(pCell, loc.x, loc.y);
 }
 
 void Landscape::addCellToPatch(Cell* pCell, Patch* pPatch, float q) {
-	pCell->setPatch((intptr)pPatch);
+	pCell->setPatch(pPatch);
 	// update the habitat type of the cell
 	pCell->setHabitat(q);
 	locn loc = pCell->getLocn();
@@ -808,7 +808,7 @@ void Landscape::addCellToPatch(Cell* pCell, Patch* pPatch, float q) {
 }
 
 void Landscape::addCellToPatch(Cell* pCell, Patch* pPatch, int hab) {
-	pCell->setPatch((intptr)pPatch);
+	pCell->setPatch(pPatch);
 	// update the habitat type of the cell
 	pCell->setHabIndex(hab);
 	locn loc = pCell->getLocn();
@@ -1450,7 +1450,6 @@ default:
 // Create & initialise patch change matrix
 void Landscape::createPatchChgMatrix(void)
 {
-	intptr patch;
 	Patch* pPatch;
 	Cell* pCell;
 	if (patchChgMatrix != 0) deletePatchChgMatrix();
@@ -1465,12 +1464,11 @@ void Landscape::createPatchChgMatrix(void)
 			}
 			else {
 				// record initial patch number
-				patch = pCell->getPatch();
-				if (patch == 0) { // matrix cell
+				pPatch = pCell->getPatch();
+				if (pPatch == nullptr) { // matrix cell
 					patchChgMatrix[y][x][0] = patchChgMatrix[y][x][1] = 0;
 				}
 				else {
-					pPatch = (Patch*)patch;
 					patchChgMatrix[y][x][0] = patchChgMatrix[y][x][1] = pPatch->getPatchNum();
 				}
 			}

--- a/Model.cpp
+++ b/Model.cpp
@@ -388,7 +388,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 									pPatch = pLandscape->findPatch(patchchange.newpatch);
 									pPatch->addCell(pCell, patchchange.x, patchchange.y);
 								}
-								pCell->setPatch((intptr)pPatch);
+								pCell->setPatch(pPatch);
 								// get next patch change
 								patchchange = pLandscape->getPatchChange(ixpchchg++);
 							}
@@ -641,7 +641,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 					pPatch = pLandscape->findPatch(patchchange.newpatch);
 					pPatch->addCell(pCell, patchchange.x, patchchange.y);
 				}
-				pCell->setPatch((intptr)pPatch);
+				pCell->setPatch(pPatch);
 				// get next patch change
 				patchchange = pLandscape->getPatchChange(ixpchchg++);
 			}

--- a/Patch.cpp
+++ b/Patch.cpp
@@ -307,8 +307,8 @@ void Patch::addPopn(patchPopn pop) {
 popns.push_back(pop);
 }
 
-// Return pointer (cast as integer) to the Population of the specified Species
-intptr Patch::getPopn(intptr sp)
+// Return pointer to the Population of the specified Species
+Population *Patch::getPopn(Species *sp)
 {
 int npops = (int)popns.size();
 for (int i = 0; i < npops; i++) {

--- a/Patch.cpp
+++ b/Patch.cpp
@@ -31,7 +31,7 @@ Patch::Patch(int seqnum,int num)
 {
 patchSeqNum = seqnum; patchNum = num; nCells = 0;
 xMin = yMin = 999999999; xMax = yMax = 0; x = y = 0;
-subCommPtr = 0;
+subCommPtr = nullptr;
 localK = 0.0;
 for (int sex = 0; sex < NSEXES; sex++) {
 	nTemp[sex] = 0;
@@ -296,11 +296,11 @@ for (int i = 0; i < ncells; i++) {
 }
 }
 
-void Patch::setSubComm(intptr sc)
+void Patch::setSubComm(SubCommunity *sc)
 { subCommPtr = sc; }
 
-// Get pointer to corresponding Sub-community (cast as an integer)
-intptr Patch::getSubComm(void)
+// Get pointer to corresponding Sub-community
+SubCommunity *Patch::getSubComm(void)
 { return subCommPtr; }
 
 void Patch::addPopn(patchPopn pop) {

--- a/Patch.h
+++ b/Patch.h
@@ -75,6 +75,7 @@ using namespace std;
 //---------------------------------------------------------------------------
 
 class Population;
+class SubCommunity;
 
 struct patchLimits {
 	int xMin,xMax,yMin,yMax;
@@ -115,9 +116,9 @@ public:
 	);
 	Cell* getRandomCell(void);
 	void setSubComm(
-		intptr		// pointer to the Sub-community cast as an integer
+		SubCommunity *		// pointer to the Sub-community
 	);
-	intptr getSubComm(void);
+	SubCommunity *getSubComm(void);
 	void addPopn(
 		patchPopn // structure holding pointers to Species and Population
 	);
@@ -151,7 +152,7 @@ public:
 	int nCells;			// no. of cells in the patch
 	int xMin,xMax,yMin,yMax; 	// min and max cell co-ordinates
 	int x,y;				// centroid co-ordinates (approx.)
-	intptr subCommPtr; // pointer (cast as integer) to sub-community associated with the patch
+	SubCommunity *subCommPtr; // pointer to sub-community associated with the patch
 	// NOTE: FOR MULTI-SPECIES MODEL, PATCH WILL NEED TO STORE K FOR EACH SPECIES
 	float localK;		// patch carrying capacity (individuals)
 	bool changed;

--- a/Patch.h
+++ b/Patch.h
@@ -74,11 +74,14 @@ using namespace std;
 
 //---------------------------------------------------------------------------
 
+class Population;
+
 struct patchLimits {
 	int xMin,xMax,yMin,yMax;
 };
 struct patchPopn {
-	intptr pSp,pPop; // pointers to Species and Population cast as integers
+	Species *pSp; // pointers to Species
+	Population *pPop; // pointers to Population
 };
 
 class Patch{
@@ -116,10 +119,10 @@ public:
 	);
 	intptr getSubComm(void);
 	void addPopn(
-		patchPopn // structure holding pointers to Species and Population cast as integers
+		patchPopn // structure holding pointers to Species and Population
 	);
-	intptr getPopn( // return pointer (cast as integer) to the Population of the Species
-		intptr // pointer to Species cast as integer
+	Population *getPopn( // return pointer to the Population of the Species
+		Species * // pointer to Species
 	);
 	void resetPopn(void);
 	void resetPossSettlers(void);

--- a/Population.cpp
+++ b/Population.cpp
@@ -59,7 +59,7 @@ Population::Population(Species* pSp, Patch* pPch, int ninds, int resol)
 	pPatch = pPch;
 	// record the new population in the patch
 	patchPopn pp;
-	pp.pSp = (intptr)pSpecies; pp.pPop = (intptr)this;
+	pp.pSp = pSpecies; pp.pPop = this;
 	pPatch->addPopn(pp);
 
 	demogrParams dem = pSpecies->getDemogr();
@@ -824,7 +824,6 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 	int disperser;
 	short othersex;
 	bool mateOK, densdepOK;
-	intptr popn;
 	int patchnum;
 	double localK, popsize, settprob;
 	Patch* pPatch = 0;
@@ -915,12 +914,11 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 						{
 							// determine whether settlement occurs in the (new) patch
 							localK = (double)pPatch->getK();
-							popn = pPatch->getPopn((intptr)pSpecies);
-							if (popn == 0) { // population has not been set up in the new patch
+							pNewPopn = pPatch->getPopn(pSpecies);
+							if (pNewPopn == nullptr) { // population has not been set up in the new patch
 								popsize = 0.0;
 							}
 							else {
-								pNewPopn = (Population*)popn;
 								popsize = (double)pNewPopn->totalPop();
 							}
 							if (localK > 0.0) {
@@ -1079,8 +1077,8 @@ bool Population::matePresent(Cell* pCell, short othersex)
 		if (pPatch->getPatchNum() > 0) { // not the matrix patch
 			if (pPatch->getK() > 0.0)
 			{ // suitable
-				pNewPopn = (Population*)pPatch->getPopn((intptr)pSpecies);
-				if (pNewPopn != 0) {
+				pNewPopn = pPatch->getPopn(pSpecies);
+				if (pNewPopn != nullptr) {
 					// count members of other sex already resident in the patch
 					for (int stg = 0; stg < nStages; stg++) {
 						popsize += pNewPopn->nInds[stg][othersex];

--- a/Population.cpp
+++ b/Population.cpp
@@ -824,7 +824,7 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 	int disperser;
 	short othersex;
 	bool mateOK, densdepOK;
-	intptr patch, popn;
+	intptr popn;
 	int patchnum;
 	double localK, popsize, settprob;
 	Patch* pPatch = 0;
@@ -859,9 +859,8 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 				if (inds[i]->getStatus() == 2)
 				{ // disperser has found a patch
 					pCell = inds[i]->getLocn(1);
-					patch = pCell->getPatch();
-					if (patch != 0) { // not no-data area
-						pPatch = (Patch*)patch;
+					pPatch = pCell->getPatch();
+					if (pPatch != nullptr) { // not no-data area
 						pPatch->incrPossSettler(pSpecies, inds[i]->getSex());
 					}
 				}
@@ -907,9 +906,8 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 				settle = inds[i]->getSettPatch();
 				if (sett.densDep)
 				{
-					patch = pCell->getPatch();
-					if (patch != 0) { // not no-data area
-						pPatch = (Patch*)patch;
+					pPatch = pCell->getPatch();
+					if (pPatch != nullptr) { // not no-data area
 						if (settle.settleStatus == 0
 							|| settle.pSettPatch != pPatch)
 							// note: second condition allows for having moved from one patch to another
@@ -1031,9 +1029,8 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 							// add to list of potential neighbouring cells if suitable, etc.
 							pCell = pLandscape->findCell(nbrloc.x, nbrloc.y);
 							if (pCell != 0) { // not no-data area
-								patch = pCell->getPatch();
-								if (patch != 0) { // not no-data area
-									pPatch = (Patch*)patch;
+								pPatch = pCell->getPatch();
+								if (pPatch != nullptr) { // not no-data area
 									patchnum = pPatch->getPatchNum();
 									if (patchnum > 0 && pPatch != inds[i]->getNatalPatch())
 									{ // not the matrix or natal patch
@@ -1072,15 +1069,13 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 // settler has reached
 bool Population::matePresent(Cell* pCell, short othersex)
 {
-	int patch;
 	Patch* pPatch;
 	Population* pNewPopn;
 	int popsize = 0;
 	bool matefound = false;
 
-	patch = (int)pCell->getPatch();
-	if (patch != 0) {
-		pPatch = (Patch*)pCell->getPatch();
+	pPatch = pCell->getPatch();
+	if (pPatch != nullptr) {
 		if (pPatch->getPatchNum() > 0) { // not the matrix patch
 			if (pPatch->getK() > 0.0)
 			{ // suitable

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -48,7 +48,7 @@ SubCommunity::~SubCommunity() {
 	if (occupancy != 0) delete[] occupancy;
 }
 
-intptr SubCommunity::getNum(void) { return subCommNum; }
+int SubCommunity::getNum(void) { return subCommNum; }
 
 Patch* SubCommunity::getPatch(void) { return pPatch; }
 

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -33,13 +33,13 @@ SubCommunity::SubCommunity(Patch* pPch, int num) {
 	subCommNum = num;
 	pPatch = pPch;
 	// record the new sub-community no. in the patch
-	pPatch->setSubComm((intptr)this);
+	pPatch->setSubComm(this);
 	initial = false;
 	occupancy = 0;
 }
 
 SubCommunity::~SubCommunity() {
-	pPatch->setSubComm(0);
+	pPatch->setSubComm(nullptr);
 	int npops = (int)popns.size();
 	for (int i = 0; i < npops; i++) { // all populations
 		delete popns[i];
@@ -384,7 +384,7 @@ void SubCommunity::completeDispersal(Landscape* pLandscape, bool connect)
 				pPop = pNewPatch->getPopn(pSpecies);
 				if (pPop == 0) { // settler is the first in a previously uninhabited patch
 					// create a new population in the corresponding sub-community
-					pSubComm = (SubCommunity*)pNewPatch->getSubComm();
+					pSubComm = pNewPatch->getSubComm();
 					pPop = pSubComm->newPopn(pLandscape, pSpecies, pNewPatch, 0);
 				}
 				pPop->recruit(settler.pInd);

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -381,7 +381,7 @@ void SubCommunity::completeDispersal(Landscape* pLandscape, bool connect)
 			// find new patch
 				pNewPatch = settler.pCell->getPatch();
 				// find population within the patch (if there is one)
-				pPop = (Population*)pNewPatch->getPopn((intptr)pSpecies);
+				pPop = pNewPatch->getPopn(pSpecies);
 				if (pPop == 0) { // settler is the first in a previously uninhabited patch
 					// create a new population in the corresponding sub-community
 					pSubComm = (SubCommunity*)pNewPatch->getSubComm();

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -379,7 +379,7 @@ void SubCommunity::completeDispersal(Landscape* pLandscape, bool connect)
 			if (settled) {
 			// settler - has already been removed from matrix population
 			// find new patch
-				pNewPatch = (Patch*)settler.pCell->getPatch();
+				pNewPatch = settler.pCell->getPatch();
 				// find population within the patch (if there is one)
 				pPop = (Population*)pNewPatch->getPopn((intptr)pSpecies);
 				if (pPop == 0) { // settler is the first in a previously uninhabited patch
@@ -391,9 +391,8 @@ void SubCommunity::completeDispersal(Landscape* pLandscape, bool connect)
 				if (connect) { // increment connectivity totals
 					int newpatch = pNewPatch->getSeqNum();
 					pPrevCell = settler.pInd->getLocn(0); // previous cell
-					intptr patch = pPrevCell->getPatch();
-					if (patch != 0) {
-						pPrevPatch = (Patch*)patch;
+					pPrevPatch = pPrevCell->getPatch();
+					if (pPrevPatch != nullptr) {
 						int prevpatch = pPrevPatch->getSeqNum();
 						pLandscape->incrConnectMatrix(prevpatch, newpatch);
 					}

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -61,7 +61,7 @@ class SubCommunity {
 public:
 	SubCommunity(Patch*,int);
 	~SubCommunity(void);
-	intptr getNum(void);
+	int getNum(void);
 	Patch* getPatch(void);
 	locn getLocn(void);
 
@@ -184,7 +184,7 @@ public:
 	);
 
 private:
-	intptr subCommNum;	// SubCommunity number
+	int subCommNum;	// SubCommunity number
 		// 0 is reserved for the SubCommunity in the inter-patch matrix
 	Patch *pPatch;
 	int *occupancy;	// pointer to occupancy array


### PR DESCRIPTION
According to [clang-tidy](https://clang.llvm.org/extra/clang-tidy/checks/performance/no-int-to-ptr.html), converting integers to pointers may have a negative performance impact.

My tests did not show any measurable performance improvement with these changes, but I consider they make the code a little cleaner.