### PR TITLE
Split functions that embed different behaviours in a single function and use a code value to select the “right” behaviour.

### DIFF
--- a/Community.cpp
+++ b/Community.cpp
@@ -611,9 +611,14 @@ commStats Community::getStats(void)
 
 // Functions to control production of output files
 
+// Close population file
+bool Community::outPopFinishLandscape() {
+	return subComms[0]->outPopFinishLandscape();
+}
+
 // Open population file and write header record
-bool Community::outPopHeaders(Species* pSpecies, int option) {
-	return subComms[0]->outPopHeaders(pLandscape, pSpecies, option);
+bool Community::outPopStartLandscape(Species* pSpecies) {
+	return subComms[0]->outPopStartLandscape(pLandscape, pSpecies);
 }
 
 // Write records to population file
@@ -628,21 +633,22 @@ void Community::outPop(int rep, int yr, int gen)
 }
 
 
-// Write records to individuals file
-void Community::outInds(int rep, int yr, int gen, int landNr) {
+// Close individuals file
+void Community::outIndsFinishReplicate() {
+	subComms[0]->outIndsFinishReplicate();
+}
 
-	if (landNr >= 0) { // open the file
-		subComms[0]->outInds(pLandscape, rep, yr, gen, landNr);
-		return;
-	}
-	if (landNr == -999) { // close the file
-		subComms[0]->outInds(pLandscape, rep, yr, gen, -999);
-		return;
-	}
+// Open individuals file and write header record
+void Community::outIndsStartReplicate(int rep, int landNr) {
+	subComms[0]->outIndsStartReplicate(pLandscape, rep, landNr);
+}
+
+// Write records to individuals file
+void Community::outIndividuals(int rep, int yr, int gen) {
 	// generate output for each sub-community (patch) in the community
 	int nsubcomms = (int)subComms.size();
 	for (int i = 0; i < nsubcomms; i++) { // all sub-communities
-		subComms[i]->outInds(pLandscape, rep, yr, gen, landNr);
+		subComms[i]->outIndividuals(pLandscape, rep, yr, gen);
 	}
 }
 

--- a/Community.cpp
+++ b/Community.cpp
@@ -492,12 +492,21 @@ void Community::dispersal(short landIx)
 
 }
 
-void Community::survival(short part, short option0, short option1)
+void Community::survival0(short option0, short option1)
 {
 	int nsubcomms = (int)subComms.size();
 	#pragma omp parallel for schedule(static,128)
 	for (int i = 0; i < nsubcomms; i++) { // all communities (including in matrix)
-		subComms[i]->survival(part, option0, option1);
+		subComms[i]->survival0(option0, option1);
+	}
+}
+
+void Community::survival1()
+{
+	int nsubcomms = (int)subComms.size();
+	#pragma omp parallel for schedule(static,128)
+	for (int i = 0; i < nsubcomms; i++) { // all communities (including in matrix)
+		subComms[i]->survival1();
 	}
 }
 

--- a/Community.cpp
+++ b/Community.cpp
@@ -661,21 +661,23 @@ void Community::outIndividuals(int rep, int yr, int gen) {
 	}
 }
 
+// Close genetics file
+void Community::outGenFinishReplicate() {
+	subComms[0]->outGenFinishReplicate();
+}
+
+// Open genetics file and write header record
+void Community::outGenStartReplicate(int rep, int landNr) {
+	subComms[0]->outGenStartReplicate(rep, landNr);
+}
+
 // Write records to genetics file
-void Community::outGenetics(int rep, int yr, int gen, int landNr) {
+void Community::outGenetics(int rep, int yr) {
 	//landParams ppLand = pLandscape->getLandParams();
-	if (landNr >= 0) { // open the file
-		subComms[0]->outGenetics(rep, yr, gen, landNr);
-		return;
-	}
-	if (landNr == -999) { // close the file
-		subComms[0]->outGenetics(rep, yr, gen, landNr);
-		return;
-	}
 	// generate output for each sub-community (patch) in the community
 	int nsubcomms = (int)subComms.size();
 	for (int i = 0; i < nsubcomms; i++) { // all sub-communities
-		subComms[i]->outGenetics(rep, yr, gen, landNr);
+		subComms[i]->outGenetics(rep, yr);
 	}
 }
 

--- a/Community.cpp
+++ b/Community.cpp
@@ -679,16 +679,17 @@ void Community::outGenetics(int rep, int yr, int gen, int landNr) {
 	}
 }
 
-// Open range file and write header record
-bool Community::outRangeHeaders(Species* pSpecies, int landNr)
+// Close range file
+bool Community::outRangeFinishLandscape()
 {
+	if (outrange.is_open()) outrange.close();
+	outrange.clear();
+	return true;
+}
 
-	if (landNr == -999) { // close the file
-		if (outrange.is_open()) outrange.close();
-		outrange.clear();
-		return true;
-	}
-
+// Open range file and write header record
+bool Community::outRangeStartLandscape(Species* pSpecies, int landNr)
+{
 	string name;
 	landParams ppLand = pLandscape->getLandParams();
 	envStochParams env = paramsStoch->getStoch();

--- a/Community.cpp
+++ b/Community.cpp
@@ -1208,9 +1208,14 @@ void Community::outOccSuit(bool view) {
 
 }
 
+// Close traits file
+bool Community::outTraitsFinishLandscape() {
+	return subComms[0]->outTraitsFinishLandscape();
+}
+
 // Open traits file and write header record
-bool Community::outTraitsHeaders(Species* pSpecies, int landNr) {
-	return subComms[0]->outTraitsHeaders(pLandscape, pSpecies, landNr);
+bool Community::outTraitsStartLandscape(Species* pSpecies, int landNr) {
+	return subComms[0]->outTraitsStartLandscape(pLandscape, pSpecies, landNr);
 }
 
 // Write records to traits file
@@ -1435,15 +1440,15 @@ void Community::writeTraitsRows(Species* pSpecies, int rep, int yr, int gen, int
 	outtraitsrows << endl;
 }
 
+// Close trait rows file
+bool Community::outTraitsRowsFinishLandscape() {
+	if (outtraitsrows.is_open()) outtraitsrows.close();
+	outtraitsrows.clear();
+	return true;
+}
+
 // Open trait rows file and write header record
-bool Community::outTraitsRowsHeaders(Species* pSpecies, int landNr) {
-
-	if (landNr == -999) { // close file
-		if (outtraitsrows.is_open()) outtraitsrows.close();
-		outtraitsrows.clear();
-		return true;
-	}
-
+bool Community::outTraitsRowsStartLandscape(Species* pSpecies, int landNr) {
 	string name;
 	emigRules emig = pSpecies->getEmig();
 	trfrRules trfr = pSpecies->getTrfr();

--- a/Community.cpp
+++ b/Community.cpp
@@ -1118,16 +1118,18 @@ void Community::outRange(Species* pSpecies, int rep, int yr, int gen)
 	outrange << endl;
 }
 
-// Open occupancy file, write header record and set up occupancy array
-bool Community::outOccupancyHeaders(int option)
+// Close occupancy file
+bool Community::outOccupancyFinishLandscape()
 {
-	if (option == -999) { // close the files
-		if (outsuit.is_open()) outsuit.close();
-		if (outoccup.is_open()) outoccup.close();
-		outsuit.clear(); outoccup.clear();
-		return true;
-	}
+	if (outsuit.is_open()) outsuit.close();
+	if (outoccup.is_open()) outoccup.close();
+	outsuit.clear(); outoccup.clear();
+	return true;
+}
 
+// Open occupancy file, write header record and set up occupancy array
+bool Community::outOccupancyStartLandscape()
+{
 	string name, nameI;
 	simParams sim = paramsSim->getSim();
 	landParams ppLand = pLandscape->getLandParams();

--- a/Community.h
+++ b/Community.h
@@ -153,12 +153,14 @@ public:
 		int,	// year
 		int	// generation
 	);
+	void outGenFinishReplicate(); // Close genetics file
+	void outGenStartReplicate( // Open genetics file and write header record
+		int,	// replicate
+		int		// Landscape number
+	);
 	void outGenetics( // Write records to genetics file
 		int,	// replicate
-		int,	// year
-		int,	// generation
-		int		// Landscape number (>= 0 to open the file, -999 to close the file
-					//									 -1 to write data records)
+		int	// year
 	);
 	// Open occupancy file, write header record and set up occupancy array
 	bool outOccupancyHeaders(

--- a/Community.h
+++ b/Community.h
@@ -162,10 +162,10 @@ public:
 		int,	// replicate
 		int	// year
 	);
+	// Close occupancy file
+	bool outOccupancyFinishLandscape();
 	// Open occupancy file, write header record and set up occupancy array
-	bool outOccupancyHeaders(
-		int		// option: -999 to close the file
-	);
+	bool outOccupancyStartLandscape();
 	void outOccupancy(void);
 	void outOccSuit(
 		bool	// TRUE if occupancy graph is to be viewed on screen

--- a/Community.h
+++ b/Community.h
@@ -133,9 +133,9 @@ public:
 		int,			// year
 		int				// generation
 	);
-	bool outPopHeaders( // Open population file and write header record
-		Species*, // pointer to Species
-		int       // option: -999 to close the file
+	bool outPopFinishLandscape(); // Close population file
+	bool outPopStartLandscape( // Open population file and write header record
+		Species* // pointer to Species
 	);
 	void outPop( // Write records to population file
 		int,	// replicate
@@ -143,12 +143,15 @@ public:
 		int		// generation
 	);
 
-	void outInds( // Write records to individuals file
+	void outIndsFinishReplicate(); // Close individuals file
+	void outIndsStartReplicate( // Open individuals file and write header record
+		int,	// replicate
+		int		// Landscape number
+	);
+	void outIndividuals( // Write records to individuals file
 		int,	// replicate
 		int,	// year
-		int,	// generation
-		int		// Landscape number (>= 0 to open the file, -999 to close the file
-					//									 -1 to write data records)
+		int	// generation
 	);
 	void outGenetics( // Write records to genetics file
 		int,	// replicate

--- a/Community.h
+++ b/Community.h
@@ -168,13 +168,15 @@ public:
 	void outOccSuit(
 		bool	// TRUE if occupancy graph is to be viewed on screen
 	);
-	bool outTraitsHeaders( // Open traits file and write header record
+	bool outTraitsFinishLandscape(); // Close traits file
+	bool outTraitsStartLandscape( // Open traits file and write header record
 		Species*,	// pointer to Species
-		int				// Landscape number (-999 to close the file)
+		int				// Landscape number
 	);
-	bool outTraitsRowsHeaders( // Open trait rows file and write header record
+	bool outTraitsRowsFinishLandscape(); // Close trait rows file
+	bool outTraitsRowsStartLandscape( // Open trait rows file and write header record
 		Species*, // pointer to Species
-		int       // Landscape number (-999 to close the file)
+		int       // Landscape number
 	);
 	void outTraits( // Write records to traits file
 		Species*,		// pointer to Species

--- a/Community.h
+++ b/Community.h
@@ -122,9 +122,10 @@ public:
 		int		// no. of rows (as above)
 	);
 
-	bool outRangeHeaders( // Open range file and write header record
+	bool outRangeFinishLandscape(); // Close range file
+	bool outRangeStartLandscape( // Open range file and write header record
 		Species*,	// pointer to Species
-		int				// Landscape number (-999 to close the file)
+		int				// Landscape number
 	);
 	void outRange( // Write record to range file
 		Species*, // pointer to Species

--- a/Community.h
+++ b/Community.h
@@ -95,15 +95,14 @@ public:
 	);
 #endif // SEASONAL || RS_RCPP
 
-	void survival(
-		short,	// part:		0 = determine survival & development,
-			//		 			1 = apply survival changes to the population
+	void survival0( // Determine survival & development
 		short,	// option0:	0 = stage 0 (juveniles) only         )
 		//					1 = all stages                       ) used by part 0 only
 		//					2 = stage 1 and above (all non-juvs) )
 		short 	// option1:	0 - development only (when survival is annual)
 		//		  	 		1 - development and survival
 	);
+	void survival1(); // Apply survival changes to the population
 	void ageIncrement(void);
 	int totalInds(void);
 	Population* findPop( // Find the population of a given species in a given patch

--- a/Genome.cpp
+++ b/Genome.cpp
@@ -232,16 +232,15 @@ void Genome::inherit(const Genome* parent, const short posn, const short chr,
 
 }
 
-void Genome::outGenHeaders(const int rep, const int landNr, const bool xtab)
+void Genome::outGenFinishReplicate()
 {
-
-	if (landNr == -999) { // close file
-		if (outGenetic.is_open()) {
-			outGenetic.close(); outGenetic.clear();
-		}
-		return;
+	if (outGenetic.is_open()) {
+		outGenetic.close(); outGenetic.clear();
 	}
+}
 
+void Genome::outGenStartReplicate(const int rep, const int landNr, const bool xtab)
+{
 	string name;
 	simParams sim = paramsSim->getSim();
 

--- a/Genome.h
+++ b/Genome.h
@@ -135,7 +135,8 @@ public:
 		const double			// s.d. of mutation magnitude (genetic scale)
 	);
 	short getNChromosomes(void);
-	void outGenHeaders(
+	void outGenFinishReplicate();
+	void outGenStartReplicate(
 		const int,	// replicate
 		const int,	// landscape number
 		const bool	// output as cross table?

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -500,13 +500,12 @@ indStats Individual::getStats(void) {
 	return s;
 }
 
-Cell* Individual::getLocn(const short option) {
-	if (option == 0) { // return previous location
-		return pPrevCell;
-	}
-	else { // return current location
-		return pCurrCell;
-	}
+Cell* Individual::getPrevCell() {
+	return pPrevCell;
+}
+
+Cell* Individual::getCurrCell() {
+	return pCurrCell;
 }
 
 Patch* Individual::getNatalPatch(void) { return pNatalPatch; }

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1784,19 +1784,25 @@ array3x3f Individual::getHabMatrix(Landscape* pLand, Species* pSpecies,
 }
 
 //---------------------------------------------------------------------------
-// Write records to individuals file
-void Individual::outGenetics(const int rep, const int year, const int spnum,
-	const int landNr, const bool xtab)
+// Close genetics file
+void Individual::outGenFinishReplicate()
 {
-	if (landNr == -1) {
-		if (pGenome != 0) {
-			pGenome->outGenetics(rep, year, spnum, indId, xtab);
-		}
-	}
-	else { // open/close file
-		pGenome->outGenHeaders(rep, landNr, xtab);
-	}
+	pGenome->outGenFinishReplicate();
+}
 
+// Open genetics file and write header record
+void Individual::outGenStartReplicate(const int rep, const int landNr, const bool xtab)
+{
+	pGenome->outGenStartReplicate(rep, landNr, xtab);
+}
+
+// Write records to genetics file
+void Individual::outGenetics(const int rep, const int year, const int spnum,
+	const bool xtab)
+{
+	if (pGenome != 0) {
+		pGenome->outGenetics(rep, year, spnum, indId, xtab);
+	}
 }
 
 #if RS_RCPP

--- a/Individual.h
+++ b/Individual.h
@@ -203,9 +203,8 @@ public:
 	int getSex(void);
 	int getStatus(void);
 	indStats getStats(void);
-	Cell* getLocn( // Return location (as pointer to Cell)
-		const short	// option: 0 = get natal locn, 1 = get current locn
-	); //
+	Cell* getPrevCell(); // Return previous location (as pointer to Cell)
+	Cell* getCurrCell(); // Return current location (as pointer to Cell)
 	Patch* getNatalPatch(void);
 	void setYearSteps(int);
 	pathSteps getSteps(void);

--- a/Individual.h
+++ b/Individual.h
@@ -271,11 +271,16 @@ public:
 		const short,	// landscape change index
 		const bool    // absorbing boundaries?
 	);
+	void outGenFinishReplicate(); // Close genetics file
+	void outGenStartReplicate( // Open genetics file and write header record
+		const int,		 	// replicate
+		const int,		 	// landscape number
+		const bool	 		// output as cross table?
+	);
 	void outGenetics( // Write records to genetics file
 		const int,		 	// replicate
 		const int,		 	// year
 		const int,		 	// species number
-		const int,		 	// landscape number
 		const bool	 		// output as cross table?
 	);
 #if RS_RCPP

--- a/Landscape.cpp
+++ b/Landscape.cpp
@@ -2438,15 +2438,17 @@ void Landscape::deleteConnectMatrix(void)
 	}
 }
 
-// Write connectivity file headers
-bool Landscape::outConnectHeaders(int option)
+// Close connectivity file
+bool Landscape::outConnectFinishLandscape()
 {
-	if (option == -999) { // close the file
-		if (outConnMat.is_open()) outConnMat.close();
-		outConnMat.clear();
-		return true;
-	}
+	if (outConnMat.is_open()) outConnMat.close();
+	outConnMat.clear();
+	return true;
+}
 
+// Open connectivity file and write header record
+bool Landscape::outConnectStartLandscape()
+{
 	simParams sim = paramsSim->getSim();
 
 	string name = paramsSim->getDir(2);
@@ -2465,39 +2467,39 @@ bool Landscape::outConnectHeaders(int option)
 }
 
 #if RS_RCPP
-// Write movement paths file headers
-void Landscape::outPathsHeaders(int rep, int option)
+// Close movement paths file
+void Landscape::outPathsFinishReplicate()
 {
-	if (option == -999) { // close the file
-		if (outMovePaths.is_open()) outMovePaths.close();
-		outMovePaths.clear();
+	if (outMovePaths.is_open()) outMovePaths.close();
+	outMovePaths.clear();
+}
+
+// Open movement paths file and write header record
+void Landscape::outPathsStartReplicate(int rep)
+{
+	simParams sim = paramsSim->getSim();
+	string name = paramsSim->getDir(2);
+	if (sim.batchMode) {
+		name += "Batch" + to_string(sim.batchNum)
+			+ "_Sim" + to_string(sim.simulation)
+			+ "_Land" + to_string(landNum)
+			+ "_Rep" + to_string(rep);
 	}
-	if (option == 0) { // open the file and write header
+	else {
+		name += "Sim" + to_string(sim.simulation)
+			+ "_Rep" + to_string(rep);
+	}
+	name += "_MovePaths.txt";
 
-		simParams sim = paramsSim->getSim();
-		string name = paramsSim->getDir(2);
-		if (sim.batchMode) {
-			name += "Batch" + to_string(sim.batchNum)
-				+ "_Sim" + to_string(sim.simulation)
-				+ "_Land" + to_string(landNum)
-				+ "_Rep" + to_string(rep);
-		}
-		else {
-			name += "Sim" + to_string(sim.simulation)
-				+ "_Rep" + to_string(rep);
-		}
-		name += "_MovePaths.txt";
-
-		outMovePaths.open(name.c_str());
-		if (outMovePaths.is_open()) {
-			outMovePaths << "Year\tIndID\tStep\tx\ty\tStatus" << endl;
-		}
-		else {
+	outMovePaths.open(name.c_str());
+	if (outMovePaths.is_open()) {
+		outMovePaths << "Year\tIndID\tStep\tx\ty\tStatus" << endl;
+	}
+	else {
 #if RSDEBUG
-			DEBUGLOG << "RunModel(): UNABLE TO OPEN MOVEMENT PATHS FILE" << endl;
+		DEBUGLOG << "RunModel(): UNABLE TO OPEN MOVEMENT PATHS FILE" << endl;
 #endif
-			outMovePaths.clear();
-		}
+		outMovePaths.clear();
 	}
 }
 #endif

--- a/Landscape.h
+++ b/Landscape.h
@@ -423,11 +423,11 @@ public:
 		int   // sequential no. of settlement Patch
 	);
 	void deleteConnectMatrix(void);
-	bool outConnectHeaders( // Write connectivity file headers
-		int		// option - set to -999 to close the connectivity file
-	);
+	bool outConnectFinishLandscape(); // Close connectivity file
+	bool outConnectStartLandscape(); // Open connectivity file and write header record
 #if RS_RCPP
-	void outPathsHeaders(int, int);
+	void outPathsFinishReplicate();
+	void outPathsStartReplicate(int);
 #endif
 	void outConnect(
 		int,	// replicate no.

--- a/Model.cpp
+++ b/Model.cpp
@@ -496,7 +496,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 
 				if (dem.stageStruct) {
 					if (sstruct.survival == 0) { // at reproduction
-						pComm->survival(0, 2, 1); // survival of all non-juvenile stages
+						pComm->survival0(2, 1); // survival of all non-juvenile stages
 					}
 				}
 
@@ -526,17 +526,17 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				// survival part 0
 				if (dem.stageStruct) {
 					if (sstruct.survival == 0) { // at reproduction
-						pComm->survival(0, 0, 1); // survival of juveniles only
+						pComm->survival0(0, 1); // survival of juveniles only
 					}
 					if (sstruct.survival == 1) { // between reproduction events
-						pComm->survival(0, 1, 1); // survival of all stages
+						pComm->survival0(1, 1); // survival of all stages
 					}
 					if (sstruct.survival == 2) { // annually
-						pComm->survival(0, 1, 0); // development only of all stages
+						pComm->survival0(1, 0); // development only of all stages
 					}
 				}
 				else { // non-structured population
-					pComm->survival(0, 1, 1);
+					pComm->survival0(1, 1);
 				}
 #if RSDEBUG
 				DEBUGLOG << "RunModel(): yr=" << yr << " gen=" << gen << " completed survival part 0" << endl;
@@ -552,10 +552,10 @@ int RunModel(Landscape* pLandscape, int seqsim)
 
 				// survival part 1
 				if (dem.stageStruct) {
-					pComm->survival(1, 0, 1);
+					pComm->survival1();
 				}
 				else { // non-structured population
-					pComm->survival(1, 0, 1);
+					pComm->survival1();
 				}
 #if RSDEBUG
 				DEBUGLOG << "RunModel(): yr=" << yr << " gen=" << gen << " completed survival part 1" << endl;
@@ -575,8 +575,8 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				pLandscape->outConnect(rep, yr);
 
 			if (dem.stageStruct && sstruct.survival == 2) {  // annual survival - all stages
-				pComm->survival(0, 1, 2);
-				pComm->survival(1, 0, 1);
+				pComm->survival0(1, 2);
+				pComm->survival1();
 #if RSDEBUG
 				DEBUGLOG << "RunModel(): yr=" << yr << " completed annual survival" << endl;
 #endif
@@ -586,7 +586,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				pComm->ageIncrement(); // increment age of all individuals
 				if (sim.outInds && yr >= sim.outStartInd && yr % sim.outIntInd == 0)
 					pComm->outIndividuals(rep, yr, -1); // list any individuals dying having reached maximum age
-				pComm->survival(1, 0, 1);						// delete any such individuals
+				pComm->survival1();						// delete any such individuals
 #if RSDEBUG
 				DEBUGLOG << "RunModel(): yr=" << yr << " completed Age_increment and final survival" << endl;
 #endif

--- a/Model.cpp
+++ b/Model.cpp
@@ -173,7 +173,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				}
 			}
 			if (sim.outOccup && sim.reps > 1)
-				if (!pComm->outOccupancyHeaders(0)) {
+				if (!pComm->outOccupancyStartLandscape()) {
 					filesOK = false;
 				}
 			if (sim.outPop) {
@@ -207,7 +207,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				pComm->outRangeFinishLandscape();
 			}
 			if (sim.outOccup && sim.reps > 1)
-				pComm->outOccupancyHeaders(-999);
+				pComm->outOccupancyFinishLandscape();
 			if (sim.outPop) {
 				pComm->outPopFinishLandscape();
 			}
@@ -708,7 +708,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 		pComm->outOccupancy();
 		pComm->outOccSuit(v.viewGraph);
 		pComm->deleteOccupancy((sim.years / sim.outIntOcc) + 1);
-		pComm->outOccupancyHeaders(-999);
+		pComm->outOccupancyFinishLandscape();
 	}
 
 	if (sim.outRange) {

--- a/Model.cpp
+++ b/Model.cpp
@@ -266,10 +266,10 @@ int RunModel(Landscape* pLandscape, int seqsim)
 			pComm->outIndsStartReplicate(rep, ppLand.landNum);
 		// open a new genetics file for each replicate
 		if (sim.outGenetics) {
-			pComm->outGenetics(rep, 0, 0, ppLand.landNum);
+			pComm->outGenStartReplicate(rep, ppLand.landNum);
 			if (!dem.stageStruct && sim.outStartGenetic == 0) {
 				// write genetic data for initialised individuals of non-strucutred population
-				pComm->outGenetics(rep, 0, 0, -1);
+				pComm->outGenetics(rep, 0);
 			}
 		}
 #if RSDEBUG
@@ -548,7 +548,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 					pComm->outIndividuals(rep, yr, gen);
 				// output Genetics
 				if (sim.outGenetics && yr >= sim.outStartGenetic && yr % sim.outIntGenetic == 0)
-					pComm->outGenetics(rep, yr, gen, -1);
+					pComm->outGenetics(rep, yr);
 
 				// survival part 1
 				if (dem.stageStruct) {
@@ -681,7 +681,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 		if (sim.outInds) // close Individuals output file
 			pComm->outIndsFinishReplicate();
 		if (sim.outGenetics) // close Genetics output file
-			pComm->outGenetics(rep, 0, 0, -999);
+			pComm->outGenFinishReplicate();
 
 		if (sim.saveVisits) {
 			pLandscape->outVisits(rep, ppLand.landNum);
@@ -724,7 +724,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 	// close Individuals & Genetics output files if open
 	// they can still be open if the simulation was stopped by the user
 	if (sim.outInds) pComm->outIndsFinishReplicate();
-	if (sim.outGenetics) pComm->outGenetics(0, 0, 0, -999);
+	if (sim.outGenetics) pComm->outGenFinishReplicate();
 
 	delete pComm; 
 	pComm = 0;

--- a/Model.cpp
+++ b/Model.cpp
@@ -191,7 +191,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 					filesOK = false;
 				}
 			if (sim.outConnect && ppLand.patchModel) // open Connectivity file
-				if (!pLandscape->outConnectHeaders(0)) {
+				if (!pLandscape->outConnectStartLandscape()) {
 					filesOK = false;
 				}
 		}
@@ -216,7 +216,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 			if (sim.outTraitsRows)
 				pComm->outTraitsRowsFinishLandscape();
 			if (sim.outConnect && ppLand.patchModel)
-				pLandscape->outConnectHeaders(-999);
+				pLandscape->outConnectFinishLandscape();
 #if RS_RCPP && !R_CMD
 			return Rcpp::List::create(Rcpp::Named("Errors") = 666);
 #else
@@ -280,7 +280,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 #if RS_RCPP
 		// open a new movement paths file for each replicate
 		if (sim.outPaths)
-			pLandscape->outPathsHeaders(rep, 0);
+			pLandscape->outPathsStartReplicate(rep);
 #endif
 
 		// years loop
@@ -690,7 +690,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 
 #if RS_RCPP
 		if (sim.outPaths)
-			pLandscape->outPathsHeaders(rep, -999);
+			pLandscape->outPathsFinishReplicate();
 #endif
 #if RSDEBUG
 		DEBUGLOG << endl << "RunModel(): finished rep=" << rep << endl;
@@ -700,7 +700,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 
 	if (sim.outConnect && ppLand.patchModel) {
 		pLandscape->deleteConnectMatrix();
-		pLandscape->outConnectHeaders(-999); // close Connectivity Matrix file
+		pLandscape->outConnectFinishLandscape(); // close Connectivity Matrix file
 	}
 
 	// Occupancy outputs

--- a/Model.cpp
+++ b/Model.cpp
@@ -183,11 +183,11 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				}
 			}
 			if (sim.outTraitsCells)
-				if (!pComm->outTraitsHeaders(pSpecies, ppLand.landNum)) {
+				if (!pComm->outTraitsStartLandscape(pSpecies, ppLand.landNum)) {
 					filesOK = false;
 				}
 			if (sim.outTraitsRows)
-				if (!pComm->outTraitsRowsHeaders(pSpecies, ppLand.landNum)) {
+				if (!pComm->outTraitsRowsStartLandscape(pSpecies, ppLand.landNum)) {
 					filesOK = false;
 				}
 			if (sim.outConnect && ppLand.patchModel) // open Connectivity file
@@ -212,9 +212,9 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				pComm->outPopFinishLandscape();
 			}
 			if (sim.outTraitsCells)
-				pComm->outTraitsHeaders(pSpecies, -999);
+				pComm->outTraitsFinishLandscape();
 			if (sim.outTraitsRows)
-				pComm->outTraitsRowsHeaders(pSpecies, -999);
+				pComm->outTraitsRowsFinishLandscape();
 			if (sim.outConnect && ppLand.patchModel)
 				pLandscape->outConnectHeaders(-999);
 #if RS_RCPP && !R_CMD
@@ -718,9 +718,9 @@ int RunModel(Landscape* pLandscape, int seqsim)
 		pComm->outPopFinishLandscape(); // close Population file
 	}
 	if (sim.outTraitsCells)
-		pComm->outTraitsHeaders(pSpecies, -999); // close Traits file
+		pComm->outTraitsFinishLandscape(); // close Traits file
 	if (sim.outTraitsRows)
-		pComm->outTraitsRowsHeaders(pSpecies, -999); // close Traits rows file
+		pComm->outTraitsRowsFinishLandscape(); // close Traits rows file
 	// close Individuals & Genetics output files if open
 	// they can still be open if the simulation was stopped by the user
 	if (sim.outInds) pComm->outIndsFinishReplicate();

--- a/Model.cpp
+++ b/Model.cpp
@@ -168,7 +168,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 		if (rep == 0) {
 			// open output files
 			if (sim.outRange) { // open Range file
-				if (!pComm->outRangeHeaders(pSpecies, ppLand.landNum)) {
+				if (!pComm->outRangeStartLandscape(pSpecies, ppLand.landNum)) {
 					filesOK = false;
 				}
 			}
@@ -204,7 +204,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 #endif
 			// close any files which may be open
 			if (sim.outRange) {
-				pComm->outRangeHeaders(pSpecies, -999);
+				pComm->outRangeFinishLandscape();
 			}
 			if (sim.outOccup && sim.reps > 1)
 				pComm->outOccupancyHeaders(-999);
@@ -712,7 +712,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 	}
 
 	if (sim.outRange) {
-		pComm->outRangeHeaders(pSpecies, -999); // close Range file
+		pComm->outRangeFinishLandscape(); // close Range file
 	}
 	if (sim.outPop) {
 		pComm->outPopFinishLandscape(); // close Population file

--- a/Model.cpp
+++ b/Model.cpp
@@ -178,7 +178,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 				}
 			if (sim.outPop) {
 				// open Population file
-				if (!pComm->outPopHeaders(pSpecies, ppLand.landNum)) {
+				if (!pComm->outPopStartLandscape(pSpecies)) {
 					filesOK = false;
 				}
 			}
@@ -209,7 +209,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 			if (sim.outOccup && sim.reps > 1)
 				pComm->outOccupancyHeaders(-999);
 			if (sim.outPop) {
-				pComm->outPopHeaders(pSpecies, -999);
+				pComm->outPopFinishLandscape();
 			}
 			if (sim.outTraitsCells)
 				pComm->outTraitsHeaders(pSpecies, -999);
@@ -263,7 +263,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 
 		// open a new individuals file for each replicate
 		if (sim.outInds)
-			pComm->outInds(rep, 0, 0, ppLand.landNum);
+			pComm->outIndsStartReplicate(rep, ppLand.landNum);
 		// open a new genetics file for each replicate
 		if (sim.outGenetics) {
 			pComm->outGenetics(rep, 0, 0, ppLand.landNum);
@@ -275,7 +275,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 #if RSDEBUG
 		// output initialised Individuals
 		if (sim.outInds)
-			pComm->outInds(rep, -1, -1, -1);
+			pComm->outIndividuals(rep, -1, -1);
 #endif
 #if RS_RCPP
 		// open a new movement paths file for each replicate
@@ -545,7 +545,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 
 				// output Individuals
 				if (sim.outInds && yr >= sim.outStartInd && yr % sim.outIntInd == 0)
-					pComm->outInds(rep, yr, gen, -1);
+					pComm->outIndividuals(rep, yr, gen);
 				// output Genetics
 				if (sim.outGenetics && yr >= sim.outStartGenetic && yr % sim.outIntGenetic == 0)
 					pComm->outGenetics(rep, yr, gen, -1);
@@ -585,7 +585,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 			if (dem.stageStruct) {
 				pComm->ageIncrement(); // increment age of all individuals
 				if (sim.outInds && yr >= sim.outStartInd && yr % sim.outIntInd == 0)
-					pComm->outInds(rep, yr, -1, -1); // list any individuals dying having reached maximum age
+					pComm->outIndividuals(rep, yr, -1); // list any individuals dying having reached maximum age
 				pComm->survival(1, 0, 1);						// delete any such individuals
 #if RSDEBUG
 				DEBUGLOG << "RunModel(): yr=" << yr << " completed Age_increment and final survival" << endl;
@@ -679,7 +679,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 			pLandscape->resetConnectMatrix(); // set connectivity matrix to zeroes
 
 		if (sim.outInds) // close Individuals output file
-			pComm->outInds(rep, 0, 0, -999);
+			pComm->outIndsFinishReplicate();
 		if (sim.outGenetics) // close Genetics output file
 			pComm->outGenetics(rep, 0, 0, -999);
 
@@ -715,7 +715,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 		pComm->outRangeHeaders(pSpecies, -999); // close Range file
 	}
 	if (sim.outPop) {
-		pComm->outPopHeaders(pSpecies, -999); // close Population file
+		pComm->outPopFinishLandscape(); // close Population file
 	}
 	if (sim.outTraitsCells)
 		pComm->outTraitsHeaders(pSpecies, -999); // close Traits file
@@ -723,7 +723,7 @@ int RunModel(Landscape* pLandscape, int seqsim)
 		pComm->outTraitsRowsHeaders(pSpecies, -999); // close Traits rows file
 	// close Individuals & Genetics output files if open
 	// they can still be open if the simulation was stopped by the user
-	if (sim.outInds) pComm->outInds(0, 0, 0, -999);
+	if (sim.outInds) pComm->outIndsFinishReplicate();
 	if (sim.outGenetics) pComm->outGenetics(0, 0, 0, -999);
 
 	delete pComm; 

--- a/Population.cpp
+++ b/Population.cpp
@@ -1629,34 +1629,37 @@ void Population::outIndividual(Landscape* pLandscape, int rep, int yr, int gen,
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
-// Write records to genetics file
-void Population::outGenetics(const int rep, const int year, const int landNr)
+// Close genetics file
+void Population::outGenFinishReplicate()
+{
+	Genome* pGenome = new Genome();
+	pGenome->outGenFinishReplicate();
+	delete pGenome;
+}
+
+// Open genetics file and write header record
+void Population::outGenStartReplicate(const int rep, const int landNr)
 {
 
 	simParams sim = paramsSim->getSim();
-
-	if (landNr >= 0) { // open file
-		Genome* pGenome;
-		genomeData gen = pSpecies->getGenomeData();
-		if (gen.trait1Chromosome) {
-			pGenome = new Genome(pSpecies->getNChromosomes(), pSpecies->getNLoci(0),
-				pSpecies->isDiploid());
-		}
-		else {
-			pGenome = new Genome(pSpecies);
-		}
-		pGenome->outGenHeaders(rep, landNr, sim.outGenXtab);
-		delete pGenome;
-		return;
+	Genome* pGenome;
+	genomeData gen = pSpecies->getGenomeData();
+	if (gen.trait1Chromosome) {
+		pGenome = new Genome(pSpecies->getNChromosomes(), pSpecies->getNLoci(0),
+			pSpecies->isDiploid());
 	}
-
-	if (landNr == -999) { // close file
-		Genome* pGenome = new Genome();
-		pGenome->outGenHeaders(rep, landNr, sim.outGenXtab);
-		delete pGenome;
-		return;
+	else {
+		pGenome = new Genome(pSpecies);
 	}
+	pGenome->outGenStartReplicate(rep, landNr, sim.outGenXtab);
+	delete pGenome;
+	return;
+}
 
+// Write records to genetics file
+void Population::outGenetics(const int rep, const int year)
+{
+	simParams sim = paramsSim->getSim();
 	short spNum = pSpecies->getSpNum();
 	short nstages = 1;
 	if (pSpecies->stageStructured()) {
@@ -1670,7 +1673,7 @@ void Population::outGenetics(const int rep, const int year, const int landNr)
 		if (year == 0 || sim.outGenType == 1
 			|| (sim.outGenType == 0 && ind.stage == 0)
 			|| (sim.outGenType == 2 && ind.stage == nstages - 1)) {
-			inds[i]->outGenetics(rep, year, spNum, landNr, sim.outGenXtab);
+			inds[i]->outGenetics(rep, year, spNum, sim.outGenXtab);
 		}
 	}
 

--- a/Population.cpp
+++ b/Population.cpp
@@ -1316,14 +1316,16 @@ void Population::clean(void)
 }
 
 //---------------------------------------------------------------------------
-// Open population file and write header record
-bool Population::outPopHeaders(int landNr, bool patchModel) {
+// Close population file
+bool Population::outPopFinishLandscape() {
+	if (outPop.is_open()) outPop.close();
+	outPop.clear();
+	return true;
+}
 
-	if (landNr == -999) { // close file
-		if (outPop.is_open()) outPop.close();
-		outPop.clear();
-		return true;
-	}
+//---------------------------------------------------------------------------
+// Open population file and write header record
+bool Population::outPopStartLandscape(int landNr, bool patchModel) {
 
 	string name;
 	simParams sim = paramsSim->getSim();
@@ -1433,17 +1435,19 @@ void Population::outPopulation(int rep, int yr, int gen, float eps,
 //---------------------------------------------------------------------------
 
 //---------------------------------------------------------------------------
-// Open individuals file and write header record
-void Population::outIndsHeaders(int rep, int landNr, bool patchModel)
+// Close individuals file
+void Population::outIndsFinishReplicate()
 {
-
-	if (landNr == -999) { // close file
-		if (outInds.is_open()) {
-			outInds.close(); outInds.clear();
-		}
-		return;
+	if (outInds.is_open()) {
+		outInds.close(); outInds.clear();
 	}
+	return;
+}
 
+//---------------------------------------------------------------------------
+// Open individuals file and write header record
+void Population::outIndsStartReplicate(int rep, int landNr, bool patchModel)
+{
 	string name;
 	demogrParams dem = pSpecies->getDemogr();
 	emigRules emig = pSpecies->getEmig();

--- a/Population.cpp
+++ b/Population.cpp
@@ -793,7 +793,7 @@ disperser Population::extractSettler(int ix) {
 
 	indStats ind = inds[ix]->getStats();
 
-	pCell = inds[ix]->getLocn(1);
+	pCell = inds[ix]->getCurrCell();
 	d.pInd = inds[ix];  d.pCell = pCell; d.yes = false;
 	if (ind.status == 4 || ind.status == 5) { // settled
 		d.yes = true;
@@ -875,7 +875,7 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 			{ // sexual species - record as potential settler in new patch
 				if (inds[i]->getStatus() == 2)
 				{ // disperser has found a patch
-					pCell = inds[i]->getLocn(1);
+					pCell = inds[i]->getCurrCell();
 					pPatch = pCell->getPatch();
 					if (pPatch != nullptr) { // not no-data area
 						pPatch->incrPossSettler(pSpecies, inds[i]->getSex());
@@ -900,7 +900,7 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 		}
 		if (ind.status == 2)
 		{ // awaiting settlement
-			pCell = inds[i]->getLocn(1);
+			pCell = inds[i]->getCurrCell();
 			if (pCell == 0) {
 				// this condition can occur in a patch-based model at the time of a dynamic landscape
 				// change when there is a range restriction in place, since a patch can straddle the
@@ -1034,7 +1034,7 @@ int Population::transfer(Landscape* pLandscape, short landIx)
 			// for kernel-based transfer only ...
 			// determine whether recruitment to a neighbouring cell is possible
 
-			pCell = inds[i]->getLocn(1);
+			pCell = inds[i]->getCurrCell();
 			newloc = pCell->getLocn();
 			vector <Cell*> nbrlist;
 			for (int dx = -1; dx < 2; dx++) {
@@ -1543,11 +1543,11 @@ void Population::outIndividual(Landscape* pLandscape, int rep, int yr, int gen,
 			else { // non-structured population
 				outInds << "\t" << ind.status;
 			}
-			pCell = inds[i]->getLocn(1);
+			pCell = inds[i]->getCurrCell();
 			locn loc;
 			if (pCell == 0) loc.x = loc.y = -1; // beyond boundary or in no-data cell
 			else loc = pCell->getLocn();
-			pCell = inds[i]->getLocn(0);
+			pCell = inds[i]->getPrevCell();
 			locn natalloc = pCell->getLocn();
 			if (ppLand.patchModel) {
 				outInds << "\t" << inds[i]->getNatalPatch()->getPatchNum();

--- a/Population.h
+++ b/Population.h
@@ -218,10 +218,14 @@ public:
 		int,				// generation
 		int					// Patch number
 	);
+	void outGenFinishReplicate(); // Close genetics file
+	void outGenStartReplicate( // Open genetics file and write header record
+		const int,		// replicate
+		const int	 		// landscape number
+	);
 	void outGenetics( // Write records to genetics file
 		const int,		// replicate
-		const int,		// year
-		const int	 		// landscape number
+		const int		// year
 	);
 	void clean(void); // Remove zero pointers to dead or dispersed individuals
 

--- a/Population.h
+++ b/Population.h
@@ -190,8 +190,9 @@ public:
 	);
 	void survival1(void); // Apply survival changes to the population
 	void ageIncrement(void);
-	bool outPopHeaders( // Open population file and write header record
-		int,	// Landscape number (-999 to close the file)
+	bool outPopFinishLandscape(); // Close population file
+	bool outPopStartLandscape( // Open population file and write header record
+		int,	// Landscape number
 		bool	// TRUE for a patch-based model, FALSE for a cell-based model
 	);
 	void outPopulation( // Write record to population file
@@ -204,9 +205,10 @@ public:
 		bool		// TRUE if there is a gradient in carrying capacity
 	);
 
-	void outIndsHeaders( // Open individuals file and write header record
+	void outIndsFinishReplicate(); // Close individuals file
+	void outIndsStartReplicate( // Open individuals file and write header record
 		int,	// replicate
-		int,	// Landscape number (-999 to close the file)
+		int,	// Landscape number
 		bool	// TRUE for a patch-based model, FALSE for a cell-based model
 	);
 	void outIndividual( // Write records to individuals file

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -629,16 +629,18 @@ int SubCommunity::stagePop(int stage) {
 	return popsize;
 }
 
+// Close traits file
+bool SubCommunity::outTraitsFinishLandscape()
+{
+	if (outtraits.is_open()) outtraits.close();
+	outtraits.clear();
+	return true;
+}
+
 // Open traits file and write header record
-bool SubCommunity::outTraitsHeaders(Landscape* pLandscape, Species* pSpecies, int landNr)
+bool SubCommunity::outTraitsStartLandscape(Landscape* pLandscape, Species* pSpecies, int landNr)
 {
 	landParams land = pLandscape->getLandParams();
-	if (landNr == -999) { // close file
-		if (outtraits.is_open()) outtraits.close();
-		outtraits.clear();
-		return true;
-	}
-
 	string name;
 	emigRules emig = pSpecies->getEmig();
 	trfrRules trfr = pSpecies->getTrfr();

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -406,7 +406,7 @@ void SubCommunity::completeDispersal(Landscape* pLandscape, bool connect)
 				pPop->recruit(settler.pInd);
 				if (connect) { // increment connectivity totals
 					int newpatch = pNewPatch->getSeqNum();
-					pPrevCell = settler.pInd->getLocn(0); // previous cell
+					pPrevCell = settler.pInd->getPrevCell();
 					pPrevPatch = pPrevCell->getPatch();
 					if (pPrevPatch != nullptr) {
 						int prevpatch = pPrevPatch->getSeqNum();

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -601,21 +601,25 @@ void SubCommunity::outIndividuals(Landscape* pLandscape, int rep, int yr, int ge
 	}
 }
 
-// Write records to individuals file
-void SubCommunity::outGenetics(int rep, int yr, int gen, int landNr)
+// Close genetics file
+void SubCommunity::outGenFinishReplicate()
 {
-	if (landNr >= 0) { // open the file
-		popns[0]->outGenetics(rep, yr, landNr);
-		return;
-	}
-	if (landNr == -999) { // close the file
-		popns[0]->outGenetics(rep, yr, landNr);
-		return;
-	}
+	popns[0]->outGenFinishReplicate();
+}
+
+// Open genetics file and write header record
+void SubCommunity::outGenStartReplicate(int rep, int landNr)
+{
+	popns[0]->outGenStartReplicate(rep, landNr);
+}
+
+// Write records to genetics file
+void SubCommunity::outGenetics(int rep, int yr)
+{
 	// generate output for each population within the sub-community (patch)
 	int npops = (int)popns.size();
 	for (int i = 0; i < npops; i++) { // all populations
-		popns[i]->outGenetics(rep, yr, landNr);
+		popns[i]->outGenetics(rep, yr);
 	}
 }
 

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -504,27 +504,33 @@ void SubCommunity::deleteOccupancy(void) {
 }
 
 //---------------------------------------------------------------------------
+// Close population file
+bool SubCommunity::outPopFinishLandscape()
+{
+	bool fileOK;
+	Population* pPop;
+
+	// as all populations may have been deleted, set up a dummy one
+	// species is not necessary
+	pPop = new Population();
+	fileOK = pPop->outPopFinishLandscape();
+	delete pPop;
+	return fileOK;
+}
+
+//---------------------------------------------------------------------------
 // Open population file and write header record
-bool SubCommunity::outPopHeaders(Landscape* pLandscape, Species* pSpecies, int option)
+bool SubCommunity::outPopStartLandscape(Landscape* pLandscape, Species* pSpecies)
 {
 	bool fileOK;
 	Population* pPop;
 	landParams land = pLandscape->getLandParams();
 
-	if (option == -999) { // close the file
-		// as all populations may have been deleted, set up a dummy one
-		// species is not necessary
-		pPop = new Population();
-		fileOK = pPop->outPopHeaders(-999, land.patchModel);
-		delete pPop;
-	}
-	else { // open the file
-		// as no population has yet been created, set up a dummy one
-		// species is necessary, as columns depend on stage and sex structure
-		pPop = new Population(pSpecies, pPatch, 0, land.resol);
-		fileOK = pPop->outPopHeaders(land.landNum, land.patchModel);
-		delete pPop;
-	}
+	// as no population has yet been created, set up a dummy one
+	// species is necessary, as columns depend on stage and sex structure
+	pPop = new Population(pSpecies, pPatch, 0, land.resol);
+	fileOK = pPop->outPopStartLandscape(land.landNum, land.patchModel);
+	delete pPop;
 	return fileOK;
 }
 
@@ -575,17 +581,19 @@ void SubCommunity::outPop(Landscape* pLandscape, int rep, int yr, int gen)
 	}
 }
 
-// Write records to individuals file
-void SubCommunity::outInds(Landscape* pLandscape, int rep, int yr, int gen, int landNr) {
+// Close individuals file
+void SubCommunity::outIndsFinishReplicate() {
+	popns[0]->outIndsFinishReplicate();
+}
+
+// Open individuals file and write header record
+void SubCommunity::outIndsStartReplicate(Landscape* pLandscape, int rep, int landNr) {
 	landParams ppLand = pLandscape->getLandParams();
-	if (landNr >= 0) { // open the file
-		popns[0]->outIndsHeaders(rep, landNr, ppLand.patchModel);
-		return;
-	}
-	if (landNr == -999) { // close the file
-		popns[0]->outIndsHeaders(rep, -999, ppLand.patchModel);
-		return;
-	}
+	popns[0]->outIndsStartReplicate(rep, landNr, ppLand.patchModel);
+}
+
+// Write records to individuals file
+void SubCommunity::outIndividuals(Landscape* pLandscape, int rep, int yr, int gen) {
 	// generate output for each population within the sub-community (patch)
 	int npops = (int)popns.size();
 	for (int i = 0; i < npops; i++) { // all populations

--- a/SubCommunity.cpp
+++ b/SubCommunity.cpp
@@ -425,20 +425,20 @@ void SubCommunity::completeDispersal(Landscape* pLandscape, bool connect)
 
 //---------------------------------------------------------------------------
 
-void SubCommunity::survival(short part, short option0, short option1)
+void SubCommunity::survival0(short option0, short option1)
 {
 	int npops = (int)popns.size();
-	if (npops < 1) return;
-	if (part == 0) {
-		float localK = pPatch->getK();
-		for (int i = 0; i < npops; i++) { // all populations
-			popns[i]->survival0(localK, option0, option1);
-		}
+	float localK = pPatch->getK();
+	for (int i = 0; i < npops; i++) { // all populations
+		popns[i]->survival0(localK, option0, option1);
 	}
-	else {
-		for (int i = 0; i < npops; i++) { // all populations
-			popns[i]->survival1();
-		}
+}
+
+void SubCommunity::survival1()
+{
+	int npops = (int)popns.size();
+	for (int i = 0; i < npops; i++) { // all populations
+		popns[i]->survival1();
 	}
 }
 

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -123,15 +123,30 @@ public:
 		Landscape*,	// pointer to Landscape
 		bool				// TRUE to increment connectivity totals
 	);
-	void survival(
-		short,	// part:		0 = determine survival & development,
-						//		 			1 = apply survival changes to the population
-		short,	// option0:	0 = stage 0 (juveniles) only         )
-						//					1 = all stages                       ) used by part 0 only
-						//					2 = stage 1 and above (all non-juvs) )
+	void survival0(	// Determine survival & development
+		short,	// option0:	0 = stage 0 (juveniles) only
+						//					1 = all stages
+						//					2 = stage 1 and above (all non-juvs)
 		short 	// option1:	0 - development only (when survival is annual)
 						//	  	 		1 - development and survival
 	);
+	void survival1();	// Apply survival changes to the population
+	inline void survival(
+		short part,	// part:		0 = determine survival & development,
+						//		 			1 = apply survival changes to the population
+		short option0,	// option0:	0 = stage 0 (juveniles) only         )
+						//					1 = all stages                       ) used by part 0 only
+						//					2 = stage 1 and above (all non-juvs) )
+		short option1	// option1:	0 - development only (when survival is annual)
+						//	  	 		1 - development and survival
+	) {
+		if (part == 0) {
+			return survival0(option0, option1);
+		}
+		else {
+			return survival1();
+		}
+	}
 	void ageIncrement(void);
 	// Find the population of a given species in a given patch
 	Population* findPop(Species*,Patch*);

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -192,10 +192,11 @@ public:
 		int					// Landscape number (>= 0 to open the file, -999 to close the file
 								//									 -1 to write data records)
 	);
-	bool outTraitsHeaders( // Open traits file and write header record
+	bool outTraitsFinishLandscape(); // Close traits file
+	bool outTraitsStartLandscape( // Open traits file and write header record
 		Landscape*,	// pointer to Landscape
 		Species*,		// pointer to Species
-		int					// Landscape number (-999 to close the file)
+		int					// Landscape number
 	);
 	traitsums outTraits( // Write records to traits file and return aggregated sums
 		Landscape*, 	// pointer to Landscape

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -146,10 +146,10 @@ public:
 	);
 	void deleteOccupancy(void);
 
-	bool outPopHeaders( // Open population file and write header record
+	bool outPopFinishLandscape(); // Close population file
+	bool outPopStartLandscape( // Open population file and write header record
 		Landscape*,	// pointer to Landscape
-		Species*,		// pointer to Species
-		int					// option: -999 to close the file
+		Species*		// pointer to Species
 	);
 	void outPop( // Write records to population file
 		Landscape*,	// pointer to Landscape
@@ -158,13 +158,17 @@ public:
 		int					// generation
 	);
 
-	void outInds( // Write records to individuals file
+	void outIndsFinishReplicate(); // Close individuals file
+	void outIndsStartReplicate( // Open individuals file and write header record
+		Landscape*,	// pointer to Landscape
+		int,				// replicate
+		int					// Landscape number
+	);
+	void outIndividuals( // Write records to individuals file
 		Landscape*,	// pointer to Landscape
 		int,				// replicate
 		int,				// year
-		int,				// generation
-		int					// Landscape number (>= 0 to open the file, -999 to close the file
-								//									 -1 to write data records)
+		int				// generation
 	);
 	void outGenetics( // Write records to genetics file
 		int,				// replicate

--- a/SubCommunity.h
+++ b/SubCommunity.h
@@ -185,12 +185,14 @@ public:
 		int,				// year
 		int				// generation
 	);
+	void outGenFinishReplicate(); // Close genetics file
+	void outGenStartReplicate( // Open genetics file and write header record
+		int,				// replicate
+		int					// Landscape number
+	);
 	void outGenetics( // Write records to genetics file
 		int,				// replicate
-		int,				// year
-		int,				// generation
-		int					// Landscape number (>= 0 to open the file, -999 to close the file
-								//									 -1 to write data records)
+		int				// year
 	);
 	bool outTraitsFinishLandscape(); // Close traits file
 	bool outTraitsStartLandscape( // Open traits file and write header record


### PR DESCRIPTION
I consider this change makes the code slightly easier read since one does not have to remember what `landNr` -999 means.

Since it avoids some useless tests and parameters, there seems to be a **tiny** performance improvement (from 656s to 649s on one of my tests).