### PR TITLE
SMS simplification

### DIFF
--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1502,7 +1502,6 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 		// unable to make a move or crossed absorbing boundary
 		// flag individual to die
 		move.dist = -123.0;
-		pCurrCell = pNewCell;
 	}
 	else {
 		newcellcost = pNewCell->getCost();
@@ -1512,8 +1511,8 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 			memory.pop(); // remove oldest memory element
 		}
 		memory.push(current); // record previous location in memory
-		pCurrCell = pNewCell;
 	}
+	pCurrCell = pNewCell;
 	return move;
 }
 

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1462,6 +1462,13 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 		}
 		assert(cumulative[8] == 1.);
 	}
+	else {
+		// unable to make a move
+		// flag individual to die
+		move.dist = -123.0;
+		pCurrCell = 0;
+		return move;
+	}
 
 	// select direction at random based on cell selection probabilities
 	// landscape boundaries and no-data cells may be reflective or absorbing

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1498,11 +1498,11 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 		pNewCell = pLand->findCell(newX, newY); // would also return 0 if outside boundary
 	}
 	assert(absorbing || (pNewCell != 0));
-	if (pNewCell == 0 || (newX == -9 || newY== -9)) { // if no cell was found
+	if (pNewCell == 0) { // if no cell was found
 		// unable to make a move or crossed absorbing boundary
 		// flag individual to die
 		move.dist = -123.0;
-		if (pNewCell == 0) pCurrCell = pNewCell;
+		pCurrCell = pNewCell;
 	}
 	else {
 		newcellcost = pNewCell->getCost();

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1491,6 +1491,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 					j++;
 				}
 			}
+			assert((y2 == 1000) && (x2 == 1000));
 			loopsteps++;
 		} while (loopsteps < 1000
 			&& (!absorbing && (newX < land.minX || newX > land.maxX

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1473,7 +1473,6 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	// select direction at random based on cell selection probabilities
 	// landscape boundaries and no-data cells may be reflective or absorbing
 	cellcost = pCurrCell->getCost();
-	int loopsteps = 0; // new counter to prevent infinite loop added 14/8/15
 	double rnd = pRandom->Random();
 	assert(rnd < cumulative[8]);
 	j = 0;
@@ -1492,7 +1491,6 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	assert((y2 == 1000) && (x2 == 1000));
 	assert(absorbing || (newX >= land.minX && newX <= land.maxX
 		&& newY >= land.minY && newY <= land.maxY));
-	loopsteps++;
 	if (newX < land.minX || newX > land.maxX
 		|| newY < land.minY || newY > land.maxY) {
 		pNewCell = 0;
@@ -1500,8 +1498,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 		pNewCell = pLand->findCell(newX, newY); // would also return 0 if outside boundary
 	}
 	assert(absorbing || (pNewCell != 0));
-	if (loopsteps >= 1000) pNewCell = 0;
-	if (loopsteps >= 1000 || pNewCell == 0 || (newX == -9 || newY== -9)) { // if no cell was found
+	if (pNewCell == 0 || (newX == -9 || newY== -9)) { // if no cell was found
 		// unable to make a move or crossed absorbing boundary
 		// flag individual to die
 		move.dist = -123.0;

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1492,6 +1492,8 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 				}
 			}
 			assert((y2 == 1000) && (x2 == 1000));
+			assert(absorbing || (newX >= land.minX && newX <= land.maxX
+				&& newY >= land.minY && newY <= land.maxY));
 			loopsteps++;
 		} while (loopsteps < 1000
 			&& (!absorbing && (newX < land.minX || newX > land.maxX

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1474,35 +1474,33 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	// landscape boundaries and no-data cells may be reflective or absorbing
 	cellcost = pCurrCell->getCost();
 	int loopsteps = 0; // new counter to prevent infinite loop added 14/8/15
-	do {
-		double rnd = pRandom->Random();
-		assert(rnd < cumulative[8]);
-		j = 0;
-		for (y2 = 0; y2 < 3; y2++) {
-			for (x2 = 0; x2 < 3; x2++) {
-				if (rnd < cumulative[j]) {
-					newX = current.x + x2 - 1;
-					newY = current.y + y2 - 1;
-					if (x2 == 1 || y2 == 1) move.dist = (float)(land.resol);
-					else move.dist = (float)(land.resol) * (float)SQRT2;
-					y2 = 999; x2 = 999; //to break out of x2 and y2 loops.
-				}
-				j++;
+	double rnd = pRandom->Random();
+	assert(rnd < cumulative[8]);
+	j = 0;
+	for (y2 = 0; y2 < 3; y2++) {
+		for (x2 = 0; x2 < 3; x2++) {
+			if (rnd < cumulative[j]) {
+				newX = current.x + x2 - 1;
+				newY = current.y + y2 - 1;
+				if (x2 == 1 || y2 == 1) move.dist = (float)(land.resol);
+				else move.dist = (float)(land.resol) * (float)SQRT2;
+				y2 = 999; x2 = 999; //to break out of x2 and y2 loops.
 			}
+			j++;
 		}
-		assert((y2 == 1000) && (x2 == 1000));
-		assert(absorbing || (newX >= land.minX && newX <= land.maxX
-			&& newY >= land.minY && newY <= land.maxY));
-		loopsteps++;
-		if (newX < land.minX || newX > land.maxX
-			|| newY < land.minY || newY > land.maxY) {
-			pNewCell = 0;
-		} else {
-			pNewCell = pLand->findCell(newX, newY); // would also return 0 if outside boundary
-		}
-		assert(absorbing || (pNewCell != 0));
-		if (loopsteps >= 1000) pNewCell = 0;
-	} while (!absorbing && pNewCell == 0 && loopsteps < 1000); // no-data cell
+	}
+	assert((y2 == 1000) && (x2 == 1000));
+	assert(absorbing || (newX >= land.minX && newX <= land.maxX
+		&& newY >= land.minY && newY <= land.maxY));
+	loopsteps++;
+	if (newX < land.minX || newX > land.maxX
+		|| newY < land.minY || newY > land.maxY) {
+		pNewCell = 0;
+	} else {
+		pNewCell = pLand->findCell(newX, newY); // would also return 0 if outside boundary
+	}
+	assert(absorbing || (pNewCell != 0));
+	if (loopsteps >= 1000) pNewCell = 0;
 	if (loopsteps >= 1000 || pNewCell == 0 || (newX == -9 || newY== -9)) { // if no cell was found
 		// unable to make a move or crossed absorbing boundary
 		// flag individual to die

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1473,6 +1473,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	do {
 		do {
 			double rnd = pRandom->Random();
+			assert(rnd < cumulative[8]);
 			j = 0;
 			for (y2 = 0; y2 < 3; y2++) {
 				for (x2 = 0; x2 < 3; x2++) {

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1427,7 +1427,6 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 
 	// set any cells beyond the current landscape limits and any no-data cells
 	// to have zero probability
-	// increment total for re-scaling to sum to unity
 
 	for (y2 = 2; y2 > -1; y2--) {
 		for (x2 = 0; x2 < 3; x2++) {
@@ -1441,29 +1440,26 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 					if (pCell == 0) nbr.cell[x2][y2] = 0.0; // no-data cell
 				}
 			}
-
-			sum_nbrs += nbr.cell[x2][y2];
 		}
 	}
 
-	// scale effective costs as probabilities summing to 1
-	if (sum_nbrs > 0.0) { // should always be the case, but safest to check...
-		for (y2 = 2; y2 > -1; y2--) {
-			for (x2 = 0; x2 < 3; x2++) {
-				nbr.cell[x2][y2] = nbr.cell[x2][y2] / (float)sum_nbrs;
-			}
-		}
-	}
-
-	// set up cell selection probabilities
+	// sum up cell weights
 	double cumulative[9];
 	int j = 0;
-	cumulative[0] = nbr.cell[0][0];
 	for (y2 = 0; y2 < 3; y2++) {
 		for (x2 = 0; x2 < 3; x2++) {
-			if (j != 0) cumulative[j] = cumulative[j - 1] + nbr.cell[x2][y2];
+			sum_nbrs += nbr.cell[x2][y2];
+			cumulative[j] = sum_nbrs;
 			j++;
 		}
+	}
+
+	// scale cumulative weights to convert them to cumulative probabilities
+	if (sum_nbrs > 0.0) { // should always be the case, but safest to check...
+		for (j = 0; j < 9; j++) {
+			cumulative[j] /= sum_nbrs;
+		}
+		assert(cumulative[8] == 1.);
 	}
 
 	// select direction at random based on cell selection probabilities

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1448,6 +1448,7 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	int j = 0;
 	for (y2 = 0; y2 < 3; y2++) {
 		for (x2 = 0; x2 < 3; x2++) {
+			assert(nbr.cell[x2][y2] >= 0);
 			sum_nbrs += nbr.cell[x2][y2];
 			cumulative[j] = sum_nbrs;
 			j++;

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1494,15 +1494,14 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 		assert(absorbing || (newX >= land.minX && newX <= land.maxX
 			&& newY >= land.minY && newY <= land.maxY));
 		loopsteps++;
-		if (loopsteps >= 1000) pNewCell = 0;
-		else {
-			if (newX < land.minX || newX > land.maxX
-				|| newY < land.minY || newY > land.maxY) {
-				pNewCell = 0;
-			} else{
-			   pNewCell = pLand->findCell(newX, newY); // would also return 0 if outside boundary
-			}
+		if (newX < land.minX || newX > land.maxX
+			|| newY < land.minY || newY > land.maxY) {
+			pNewCell = 0;
+		} else {
+			pNewCell = pLand->findCell(newX, newY); // would also return 0 if outside boundary
 		}
+		assert(absorbing || (pNewCell != 0));
+		if (loopsteps >= 1000) pNewCell = 0;
 	} while (!absorbing && pNewCell == 0 && loopsteps < 1000); // no-data cell
 	if (loopsteps >= 1000 || pNewCell == 0 || (newX == -9 || newY== -9)) { // if no cell was found
 		// unable to make a move or crossed absorbing boundary

--- a/Individual.cpp
+++ b/Individual.cpp
@@ -1475,29 +1475,25 @@ movedata Individual::smsMove(Landscape* pLand, Species* pSpecies,
 	cellcost = pCurrCell->getCost();
 	int loopsteps = 0; // new counter to prevent infinite loop added 14/8/15
 	do {
-		do {
-			double rnd = pRandom->Random();
-			assert(rnd < cumulative[8]);
-			j = 0;
-			for (y2 = 0; y2 < 3; y2++) {
-				for (x2 = 0; x2 < 3; x2++) {
-					if (rnd < cumulative[j]) {
-						newX = current.x + x2 - 1;
-						newY = current.y + y2 - 1;
-						if (x2 == 1 || y2 == 1) move.dist = (float)(land.resol);
-						else move.dist = (float)(land.resol) * (float)SQRT2;
-						y2 = 999; x2 = 999; //to break out of x2 and y2 loops.
-					}
-					j++;
+		double rnd = pRandom->Random();
+		assert(rnd < cumulative[8]);
+		j = 0;
+		for (y2 = 0; y2 < 3; y2++) {
+			for (x2 = 0; x2 < 3; x2++) {
+				if (rnd < cumulative[j]) {
+					newX = current.x + x2 - 1;
+					newY = current.y + y2 - 1;
+					if (x2 == 1 || y2 == 1) move.dist = (float)(land.resol);
+					else move.dist = (float)(land.resol) * (float)SQRT2;
+					y2 = 999; x2 = 999; //to break out of x2 and y2 loops.
 				}
+				j++;
 			}
-			assert((y2 == 1000) && (x2 == 1000));
-			assert(absorbing || (newX >= land.minX && newX <= land.maxX
-				&& newY >= land.minY && newY <= land.maxY));
-			loopsteps++;
-		} while (loopsteps < 1000
-			&& (!absorbing && (newX < land.minX || newX > land.maxX
-				|| newY < land.minY || newY > land.maxY)));
+		}
+		assert((y2 == 1000) && (x2 == 1000));
+		assert(absorbing || (newX >= land.minX && newX <= land.maxX
+			&& newY >= land.minY && newY <= land.maxY));
+		loopsteps++;
 		if (loopsteps >= 1000) pNewCell = 0;
 		else {
 			if (newX < land.minX || newX > land.maxX


### PR DESCRIPTION
I did my best to simplify the code for the SMS movement.

As I understand it, looping until finding a suitable next cell was only needed because the computed probabilities did not sum up to 1.

I fixed this and added a bunch of asserts to ensure that a single iteration is needed.

It might be easier to review the commits one by one rather than the PR as a whole.

This simplification seems to lead to a **small** performance improvement (from 655s to 639s on my tests).

Any comment/suggestion/question is welcome.